### PR TITLE
Anpassen der Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ lang-make:
 lang-compile:
 	pipenv run python manage.py compilemessages
 black-check:
-    docker-compose run --rm web black . --check
+	docker-compose run --rm web black . --check
 black-format:
-    docker-compose run --rm web black .
+	docker-compose run --rm web black .
 pytest:
-    docker-compose run --rm web pytest
+	docker-compose run --rm web pytest

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,5 @@ black-check:
     docker-compose run --rm web black . --check
 black-format:
     docker-compose run --rm web black .
+pytest:
+    docker-compose run --rm web pytest

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -3,10 +3,10 @@ from api.models import User, Contract
 
 
 @pytest.fixture
-def user_model_class_instace():
-    return User()
+def user_model_class():
+    return User
 
 
 @pytest.fixture
-def contract_model_class_instance():
-    return Contract()
+def contract_model_class():
+    return Contract

--- a/api/tests/test_base_models.py
+++ b/api/tests/test_base_models.py
@@ -47,62 +47,56 @@ class TestUserFields:
     2. Do all fields have the correct format/class instance
     """
 
-    def test_model_has_id_field(self, user_model_class_instace):
-        assert hasattr(user_model_class_instace, "id")
+    def test_model_has_id_field(self, user_model_class):
+        assert hasattr(user_model_class, "id")
 
-    def test_model_has_email_field(self, user_model_class_instace):
-        assert hasattr(user_model_class_instace, "email")
+    def test_model_has_email_field(self, user_model_class):
+        assert hasattr(user_model_class, "email")
 
-    def test_model_has_first_name_field(self, user_model_class_instace):
-        assert hasattr(user_model_class_instace, "first_name")
+    def test_model_has_first_name_field(self, user_model_class):
+        assert hasattr(user_model_class, "first_name")
 
-    def test_model_has_last_name_field(self, user_model_class_instace):
-        assert hasattr(user_model_class_instace, "last_name")
+    def test_model_has_last_name_field(self, user_model_class):
+        assert hasattr(user_model_class, "last_name")
 
-    def test_model_has_personal_number_filed(self, user_model_class_instace):
-        assert hasattr(user_model_class_instace, "personal_number")
+    def test_model_has_personal_number_filed(self, user_model_class):
+        assert hasattr(user_model_class, "personal_number")
 
-    def test_model_has_created_at_field(self, user_model_class_instace):
-        assert hasattr(user_model_class_instace, "created_at")
+    def test_model_has_created_at_field(self, user_model_class):
+        assert hasattr(user_model_class, "created_at")
 
-    def test_model_has_modified_at_field(self, user_model_class_instace):
-        assert hasattr(user_model_class_instace, "modified_at")
+    def test_model_has_modified_at_field(self, user_model_class):
+        assert hasattr(user_model_class, "modified_at")
 
-    def test_field_type_id(self, user_model_class_instace):
+    def test_field_type_id(self, user_model_class):
+        assert isinstance(user_model_class._meta.get_field("id"), models.UUIDField)
+
+    def test_field_type_email(self, user_model_class):
+        assert isinstance(user_model_class._meta.get_field("email"), models.EmailField)
+
+    def test_field_type_first_name(self, user_model_class):
         assert isinstance(
-            user_model_class_instace._meta.get_field("id"), models.UUIDField
+            user_model_class._meta.get_field("first_name"), models.CharField
         )
 
-    def test_field_type_email(self, user_model_class_instace):
+    def test_field_type_last_name(self, user_model_class):
         assert isinstance(
-            user_model_class_instace._meta.get_field("email"), models.EmailField
+            user_model_class._meta.get_field("last_name"), models.CharField
         )
 
-    def test_field_type_first_name(self, user_model_class_instace):
+    def test_field_type_personal_number(self, user_model_class):
         assert isinstance(
-            user_model_class_instace._meta.get_field("first_name"), models.CharField
+            user_model_class._meta.get_field("personal_number"), models.CharField
         )
 
-    def test_field_type_last_name(self, user_model_class_instace):
+    def test_field_type_created_at(self, user_model_class):
         assert isinstance(
-            user_model_class_instace._meta.get_field("last_name"), models.CharField
+            user_model_class._meta.get_field("created_at"), models.DateTimeField
         )
 
-    def test_field_type_personal_number(self, user_model_class_instace):
+    def test_field_type_modified_at(self, user_model_class):
         assert isinstance(
-            user_model_class_instace._meta.get_field("personal_number"),
-            models.CharField,
-        )
-
-    def test_field_type_created_at(self, user_model_class_instace):
-        assert isinstance(
-            user_model_class_instace._meta.get_field("created_at"), models.DateTimeField
-        )
-
-    def test_field_type_modified_at(self, user_model_class_instace):
-        assert isinstance(
-            user_model_class_instace._meta.get_field("modified_at"),
-            models.DateTimeField,
+            user_model_class._meta.get_field("modified_at"), models.DateTimeField
         )
 
 
@@ -113,87 +107,80 @@ class TestContractFields:
     2. Do all fields have the correct format/class instance
     """
 
-    def test_model_has_id(self, contract_model_class_instance):
-        assert hasattr(contract_model_class_instance, "id")
+    def test_model_has_id(self, contract_model_class):
+        assert hasattr(contract_model_class, "id")
 
-    def test_model_has_user(self, contract_model_class_instance):
-        assert contract_model_class_instance._meta.get_field("user")
+    def test_model_has_user(self, contract_model_class):
+        assert hasattr(contract_model_class, "user")
 
-    def test_model_has_name(self, contract_model_class_instance):
-        assert hasattr(contract_model_class_instance, "name")
+    def test_model_has_name(self, contract_model_class):
+        assert hasattr(contract_model_class, "name")
 
-    def test_model_has_hours(self, contract_model_class_instance):
-        assert hasattr(contract_model_class_instance, "hours")
+    def test_model_has_hours(self, contract_model_class):
+        assert hasattr(contract_model_class, "hours")
 
-    def test_model_has_start_date(self, contract_model_class_instance):
-        assert hasattr(contract_model_class_instance, "start_date")
+    def test_model_has_start_date(self, contract_model_class):
+        assert hasattr(contract_model_class, "start_date")
 
-    def test_model_has_end_date(self, contract_model_class_instance):
-        assert hasattr(contract_model_class_instance, "end_date")
+    def test_model_has_end_date(self, contract_model_class):
+        assert hasattr(contract_model_class, "end_date")
 
-    def test_model_has_created_at(self, contract_model_class_instance):
-        assert hasattr(contract_model_class_instance, "created_at")
+    def test_model_has_created_at(self, contract_model_class):
+        assert hasattr(contract_model_class, "created_at")
 
-    def test_model_has_created_by(self, contract_model_class_instance):
-        assert contract_model_class_instance._meta.get_field("created_by")
+    def test_model_has_created_by(self, contract_model_class):
+        assert hasattr(contract_model_class, "created_by")
 
-    def test_model_has_modified_at(self, contract_model_class_instance):
-        assert hasattr(contract_model_class_instance, "modified_at")
+    def test_model_has_modified_at(self, contract_model_class):
+        assert hasattr(contract_model_class, "modified_at")
 
-    def test_model_has_modified_by(self, contract_model_class_instance):
-        assert contract_model_class_instance._meta.get_field("modified_by")
+    def test_model_has_modified_by(self, contract_model_class):
+        assert hasattr(contract_model_class, "modified_by")
 
-    def test_field_type_id(self, contract_model_class_instance):
+    def test_field_type_id(self, contract_model_class):
+        assert isinstance(contract_model_class._meta.get_field("id"), models.UUIDField)
+
+    def test_field_type_user(self, contract_model_class):
         assert isinstance(
-            contract_model_class_instance._meta.get_field("id"), models.UUIDField
+            contract_model_class._meta.get_field("user"), models.ForeignKey
         )
 
-    def test_field_type_user(self, contract_model_class_instance):
+    def test_field_type_name(self, contract_model_class):
         assert isinstance(
-            contract_model_class_instance._meta.get_field("user"), models.ForeignKey
+            contract_model_class._meta.get_field("name"), models.CharField
         )
 
-    def test_field_type_name(self, contract_model_class_instance):
+    def test_field_type_hours(self, contract_model_class):
         assert isinstance(
-            contract_model_class_instance._meta.get_field("name"), models.CharField
+            contract_model_class._meta.get_field("hours"), models.FloatField
         )
 
-    def test_field_type_hours(self, contract_model_class_instance):
+    def test_field_type_start_date(self, contract_model_class):
         assert isinstance(
-            contract_model_class_instance._meta.get_field("hours"), models.FloatField
+            contract_model_class._meta.get_field("start_date"), models.DateField
         )
 
-    def test_field_type_start_date(self, contract_model_class_instance):
+    def test_field_type_end_date(self, contract_model_class):
         assert isinstance(
-            contract_model_class_instance._meta.get_field("start_date"),
-            models.DateField,
+            contract_model_class._meta.get_field("end_date"), models.DateField
         )
 
-    def test_field_type_end_date(self, contract_model_class_instance):
+    def test_field_type_created_at(self, contract_model_class):
         assert isinstance(
-            contract_model_class_instance._meta.get_field("end_date"), models.DateField
+            contract_model_class._meta.get_field("created_at"), models.DateTimeField
         )
 
-    def test_field_type_created_at(self, contract_model_class_instance):
+    def test_field_type_created_by(self, contract_model_class):
         assert isinstance(
-            contract_model_class_instance._meta.get_field("created_at"),
-            models.DateTimeField,
+            contract_model_class._meta.get_field("created_by"), models.ForeignKey
         )
 
-    def test_field_type_created_by(self, contract_model_class_instance):
+    def test_field_type_modified_at(self, contract_model_class):
         assert isinstance(
-            contract_model_class_instance._meta.get_field("created_by"),
-            models.ForeignKey,
+            contract_model_class._meta.get_field("modified_at"), models.DateTimeField
         )
 
-    def test_field_type_modified_at(self, contract_model_class_instance):
+    def test_field_type_modified_by(self, contract_model_class):
         assert isinstance(
-            contract_model_class_instance._meta.get_field("modified_at"),
-            models.DateTimeField,
-        )
-
-    def test_field_type_modified_by(self, contract_model_class_instance):
-        assert isinstance(
-            contract_model_class_instance._meta.get_field("modified_by"),
-            models.ForeignKey,
+            contract_model_class._meta.get_field("modified_by"), models.ForeignKey
         )


### PR DESCRIPTION
Um zu testen ob ein Foreignkey-/OneToOne-/ManyToManyField definiert ist muss bei einer Model-Instance von `hasattr(Instance, "<field_name>)` zu  `Instance._meta.get_field("<field_name>")`über geganen werden. 

Dies kann man umgehen, indem man statt einer Instanze die uninstanzierte Klasse untersucht.

Dazu wird in diesem PR:

- [x] conftest.py gibt Klasse uninstanziert aus

- [x]  make pytest einführen

NOTE: Zweiter Punkt erhöht Bequemlichkeit des Testen.