### PR TITLE
Contract api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: init ci analyze build rebuild migrate lang-make lang-compile
 
 init:
+	pip install --upgrade pip
 	pip install pipenv --upgrade
 	pipenv install --dev --skip-lock
 ci:

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -1,0 +1,23 @@
+import jwt
+from django.conf import settings
+from rest_framework.permissions import IsAuthenticated
+
+
+class AccessOwnDataPermission(IsAuthenticated):
+    def has_permission(self, request, view):
+        is_authenticated = super(AccessOwnDataPermission, self).has_permission(
+            request, view
+        )
+
+        if is_authenticated:
+            jwt_token = request.META.get("HTTP_AUTHORIZATION").split()[-1]
+            user_id = jwt.decode(jwt_token, settings.SECRET_KEY, algorithm="HS256")[
+                "user_id"
+            ]
+            request.user_id = user_id
+
+        return is_authenticated
+
+    def has_object_permission(self, request, view, obj):
+
+        return request.user_id == obj.user.id

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -4,19 +4,5 @@ from rest_framework.permissions import IsAuthenticated
 
 
 class AccessOwnDataPermission(IsAuthenticated):
-    def has_permission(self, request, view):
-        is_authenticated = super(AccessOwnDataPermission, self).has_permission(
-            request, view
-        )
-
-        if is_authenticated:
-            jwt_token = request.META.get("HTTP_AUTHORIZATION").split()[-1]
-            user_id = jwt.decode(jwt_token, settings.SECRET_KEY, algorithm="HS256")[
-                "user_id"
-            ]
-            request.user_id = user_id
-
-        return is_authenticated
-
     def has_object_permission(self, request, view, obj):
-        return request.user_id == str(obj.user.id)
+        return request.user.id == obj.user.id

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -19,5 +19,4 @@ class AccessOwnDataPermission(IsAuthenticated):
         return is_authenticated
 
     def has_object_permission(self, request, view, obj):
-
-        return request.user_id == obj.user.id
+        return request.user_id == str(obj.user.id)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -13,7 +13,8 @@ class ContractSerializer(serializers.ModelSerializer):
             # Will be set automatically by the Model
             "modified_at": {"required": False},
             "created_by": {"write_only": True},
-            "modified_by": {"write_only": False},
+            "modified_by": {"write_only": True},
+            "user": {"write_only": True},
         }
 
     def validate(self, attrs):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -78,7 +78,7 @@ class ContractSerializer(serializers.ModelSerializer):
         return hours
 
     def add_user_id(self, request, data):
-        user_id = request.user_id
+        user_id = request.user.id
         data["user"] = user_id
         data["created_by"] = user_id
         data["modified_by"] = user_id
@@ -95,6 +95,6 @@ class ContractSerializer(serializers.ModelSerializer):
             # Set "modified_by" to the user issuing the request
             data.pop("user", None)
             data.pop("created_by", None)
-            data["modified_by"] = request.user_id
+            data["modified_by"] = request.user.id
 
         return super(ContractSerializer, self).to_internal_value(data)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -24,8 +24,14 @@ class ContractSerializer(serializers.ModelSerializer):
         :param attrs:
         :return:
         """
+        start_date = attrs.get("start_date")
+        end_date = attrs.get("end_date")
 
-        if attrs.get("start_date") > attrs.get("end_date"):
+        if self.instance and self.partial:
+            start_date = attrs.get("start_date", self.instance.start_date)
+            end_date = attrs.get("end_date", self.instance.end_date)
+
+        if start_date > end_date:
             raise serializers.ValidationError(
                 "Der Beginn eines Vertrages muss vor dessen Ende liegen."
             )

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -20,7 +20,7 @@ class ContractSerializer(serializers.ModelSerializer):
     def validate(self, attrs):
         """
         Object-level validation.
-        Here we validate : start_date is, timewise, prior to end_date
+        Validate that the start_date is smaller than the end_date.
         :param attrs:
         :return:
         """
@@ -34,7 +34,7 @@ class ContractSerializer(serializers.ModelSerializer):
 
     def validate_start_date(self, start_date):
         """
-        Furthermore we check that the day of the start_date is the first or 15th of the month.
+        Check that the day of the start_date is the 1st or 15th day of the month.
         :param start_date:
         :return: hours
         """
@@ -47,24 +47,24 @@ class ContractSerializer(serializers.ModelSerializer):
 
     def validate_end_date(self, end_date):
         """
-        We check that the Contract ends either on the 14. or last day of a month.
+        Check that the contract ends either on the 14. or last day of a month.
         :param end_date:
         :return:
         """
         if end_date.day not in (14, monthrange(end_date.year, end_date.month)[1]):
             raise serializers.ValidationError(
-                "Ein Vertrag durf nur am 14. oder letzten Tag eines Monats enden."
+                "Ein Vertrag darf nur am 14. oder letzten Tag eines Monats enden."
             )
 
         return end_date
 
     def validate_hours(self, hours):
         """
-        We check wether the provided value for hours is greater than zero.
+        Check that the provided value for hours is greater than zero.
         :param hours:
         :return: hours
         """
-        if hours < 0:
+        if hours <= 0:
             raise serializers.ValidationError(
                 "Die Anzahl der Stunden muss größer 0 sein."
             )

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -3,7 +3,31 @@ from calendar import monthrange
 from api.models import Contract
 
 
-class ContractSerializer(serializers.ModelSerializer):
+class RestrictModificationModelSerializer(serializers.ModelSerializer):
+    def add_user_id(self, request, data):
+        user_id = request.user.id
+        data["user"] = user_id
+        data["created_by"] = user_id
+        data["modified_by"] = user_id
+        return data
+
+    def to_internal_value(self, data):
+        request = self.context["request"]
+        data = data.dict()
+        if request.method in ["POST", "PUT"]:
+            data = self.add_user_id(request, data)
+
+        if request.method == "PATCH":
+            # Not allowed keys "user" and "created_by" in a PATCH-Request.
+            # Set "modified_by" to the user issuing the request
+            data.pop("user", None)
+            data.pop("created_by", None)
+            data["modified_by"] = request.user.id
+
+        return super(RestrictModificationModelSerializer, self).to_internal_value(data)
+
+
+class ContractSerializer(RestrictModificationModelSerializer):
     class Meta:
         model = Contract
         fields = "__all__"
@@ -76,25 +100,3 @@ class ContractSerializer(serializers.ModelSerializer):
             )
 
         return hours
-
-    def add_user_id(self, request, data):
-        user_id = request.user.id
-        data["user"] = user_id
-        data["created_by"] = user_id
-        data["modified_by"] = user_id
-        return data
-
-    def to_internal_value(self, data):
-        request = self.context["request"]
-        data = data.dict()
-        if request.method in ["POST", "PUT"]:
-            data = self.add_user_id(request, data)
-
-        if request.method == "PATCH":
-            # Not allowed keys "user" and "created_by" in a PATCH-Request.
-            # Set "modified_by" to the user issuing the request
-            data.pop("user", None)
-            data.pop("created_by", None)
-            data["modified_by"] = request.user.id
-
-        return super(ContractSerializer, self).to_internal_value(data)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,0 +1,71 @@
+from rest_framework import serializers
+from calendar import monthrange
+from api.models import Contract
+
+
+class ContractSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Contract
+        fields = "__all__"
+        extra_kwargs = {
+            # Will be set automatically by the Model
+            "created_at": {"required": False},
+            # Will be set automatically by the Model
+            "modified_at": {"required": False},
+            "created_by": {"write_only": True},
+            "modified_by": {"write_only": False},
+        }
+
+    def validate(self, attrs):
+        """
+        Object-level validation.
+        Here we validate : start_date is, timewise, prior to end_date
+        :param attrs:
+        :return:
+        """
+
+        if attrs.get("start_date") > attrs.get("end_date"):
+            raise serializers.ValidationError(
+                "Der Beginn eines Vertrages muss vor dessen Ende liegen."
+            )
+
+        return attrs
+
+    def validate_start_date(self, start_date):
+        """
+        Furthermore we check that the day of the start_date is the first or 15th of the month.
+        :param start_date:
+        :return: hours
+        """
+        if start_date.day not in (1, 15):
+            raise serializers.ValidationError(
+                "Ein Vertrag darf nur am 1. oder 15. eines Monats beginnen."
+            )
+
+        return start_date
+
+    def validate_end_date(self, end_date):
+        """
+        We check that the Contract ends either on the 14. or last day of a month.
+        :param end_date:
+        :return:
+        """
+        if end_date.day not in (14, monthrange(end_date.year, end_date.month)[1]):
+            raise serializers.ValidationError(
+                "Ein Vertrag durf nur am 14. oder letzten Tag eines Monats enden."
+            )
+
+        return end_date
+
+    def validate_hours(self, hours):
+        """
+        We check wether the provided value for hours is greater than zero.
+        :param hours:
+        :return: hours
+        """
+        if hours < 0:
+            raise serializers.ValidationError(
+                "Die Anzahl der Stunden muss größer 0 sein."
+            )
+
+        return hours

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -100,9 +100,9 @@ def negative_hours_contract_json(valid_contract_json):
 @pytest.fixture
 def invalid_uuid_contract_json(valid_contract_json):
     random_uuid = uuid.uuid4()
-    valid_contract_json.pop("user")
-    valid_contract_json.pop("created_by")
-    valid_contract_json.pop("modified_by")
+    valid_contract_json["user"] = random_uuid
+    valid_contract_json["created_by"] = random_uuid
+    valid_contract_json["modified_by"] = random_uuid
     valid_contract_json.pop("created_at")
     valid_contract_json.pop("modified_at")
     return valid_contract_json

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from api.models import User, Contract, Shift, Report
+from pytz import datetime
 
 
 @pytest.fixture
@@ -20,3 +21,68 @@ def shift_model_class():
 @pytest.fixture
 def report_model_class():
     return Report
+
+
+@pytest.fixture
+def user_object():
+    return User.objects.create_user(
+        email="test@test.com",
+        first_name="Testfirstname",
+        last_name="Testlastname",
+        personal_number="1234567890",
+        password="Test_password",
+    )
+
+
+@pytest.fixture
+def valid_contract_json(user_object):
+    name = "Test Contract"
+    hours = 20.0
+    start_date = datetime.date(2019, 1, 1)
+    end_date = datetime.date(2019, 1, 31)
+    user = user_object.id
+
+    created_at = datetime.datetime(2018, 12, 31, hour=10)
+    modified_at = created_at
+
+    data = {
+        "name": name,
+        "hours": hours,
+        "start_date": start_date,
+        "end_date": end_date,
+        "user": user,
+        "created_by": user,
+        "modified_by": user,
+        "created_at": created_at,
+        "modified_at": modified_at,
+    }
+
+    return data
+
+
+@pytest.fixture
+def end_date_before_start_date_contract_json(valid_contract_json):
+    start_date = datetime.date(2019, 2, 1)
+    valid_contract_json["start_date"] = start_date
+    return valid_contract_json
+
+
+@pytest.fixture
+def start_date_day_incorrect_contract_json(valid_contract_json):
+    start_date = datetime.date(2019, 1, 6)
+    valid_contract_json["start_date"] = start_date
+    return valid_contract_json
+
+
+@pytest.fixture
+def end_date_day_incorrect_contract_json(valid_contract_json):
+    end_date = datetime.date(2019, 1, 22)
+    valid_contract_json["end_date"] = end_date
+    return valid_contract_json
+
+
+@pytest.fixture
+def negative_hours_contract_json(valid_contract_json):
+    hours = -20.0
+    valid_contract_json["hours"] = hours
+    return valid_contract_json

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -39,6 +39,29 @@ def user_object():
 
 
 @pytest.fixture
+def create_n_user_objects():
+    email = "test{}@test.com"
+    first_name = "Testfirstname"
+    last_name = "Testlastname"
+    personal_number = "1234567890"
+    password = "Test_password"
+
+    def create_users(n):
+        return [
+            User.objects.create(
+                email=email.format(i),
+                first_name=first_name,
+                last_name=last_name,
+                personal_number=personal_number,
+                password=password,
+            )
+            for i in range(n)
+        ]
+
+    return create_users
+
+
+@pytest.fixture
 def user_object_password():
     return "Test_password"
 
@@ -121,3 +144,36 @@ def user_object_jwt(user_object, client, user_object_password):
     )
 
     return user_response.data["access"]
+
+
+@pytest.fixture
+def create_n_contract_objects(user_object):
+    name = "Test Contract{}"
+    hours = 20.0
+    start_date = datetime.date(2019, 1, 1)
+    end_date = datetime.date(2019, 1, 31)
+
+    def create_contracts(n, user):
+        for i in range(n):
+            Contract.objects.create(
+                name=name.format(i),
+                hours=hours,
+                start_date=start_date,
+                end_date=end_date,
+                user=user,
+                created_by=user,
+                modified_by=user,
+            )
+
+    return create_contracts
+
+
+@pytest.fixture
+def db_creation_contracts_list_endpoint(
+    user_object, create_n_user_objects, create_n_contract_objects
+):
+    # Create 2 contracts for the User to test
+    create_n_contract_objects(2, user_object)
+    # Create another user and 2 Contracts for him
+    different_user = create_n_user_objects(1)[0]
+    create_n_contract_objects(2, different_user)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -199,3 +199,9 @@ def db_creation_contracts_list_endpoint(
     create_n_contract_objects((1, 3), user_object)
     # Create another user and 2 Contracts for him
     create_n_contract_objects((1, 3), diff_user_object)
+
+
+@pytest.fixture
+def invalid_uuid_contract_put_endpoint(invalid_uuid_contract_json, contract_object):
+    invalid_uuid_contract_json["id"] = contract_object.id
+    return invalid_uuid_contract_json

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,6 +1,10 @@
 import pytest
-from api.models import User, Contract, Shift, Report
+import uuid
 from pytz import datetime
+from rest_framework.test import APIClient
+from django.urls import reverse
+
+from api.models import User, Contract, Shift, Report
 
 
 @pytest.fixture
@@ -35,14 +39,19 @@ def user_object():
 
 
 @pytest.fixture
+def user_object_password():
+    return "Test_password"
+
+
+@pytest.fixture
 def valid_contract_json(user_object):
     name = "Test Contract"
     hours = 20.0
-    start_date = datetime.date(2019, 1, 1)
-    end_date = datetime.date(2019, 1, 31)
+    start_date = datetime.date(2019, 1, 1).isoformat()
+    end_date = datetime.date(2019, 1, 31).isoformat()
     user = user_object.id
 
-    created_at = datetime.datetime(2018, 12, 31, hour=10)
+    created_at = datetime.datetime(2018, 12, 31, hour=10).isoformat()
     modified_at = created_at
 
     data = {
@@ -86,3 +95,29 @@ def negative_hours_contract_json(valid_contract_json):
     hours = -20.0
     valid_contract_json["hours"] = hours
     return valid_contract_json
+
+
+@pytest.fixture
+def invalid_uuid_contract_json(valid_contract_json):
+    random_uuid = uuid.uuid4()
+    valid_contract_json.pop("user")
+    valid_contract_json.pop("created_by")
+    valid_contract_json.pop("modified_by")
+    valid_contract_json.pop("created_at")
+    valid_contract_json.pop("modified_at")
+    return valid_contract_json
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+@pytest.fixture
+def user_object_jwt(user_object, client, user_object_password):
+    user_response = client.post(
+        path=reverse("jwt-create"),
+        data={"email": user_object.email, "password": user_object_password},
+    )
+
+    return user_response.data["access"]

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,7 +1,8 @@
 import pytest
 import uuid
 from pytz import datetime
-from rest_framework.test import APIClient
+from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
+from rest_framework.request import Request, QueryDict
 from django.urls import reverse
 
 from api.models import User, Contract, Shift, Report
@@ -93,10 +94,26 @@ def valid_contract_json(user_object):
 
 
 @pytest.fixture
+def valid_contract_querydict(valid_contract_json):
+    qdict = QueryDict("", mutable=True)
+    qdict.update(valid_contract_json)
+    return qdict
+
+
+@pytest.fixture
 def end_date_before_start_date_contract_json(valid_contract_json):
     start_date = datetime.date(2019, 2, 1)
     valid_contract_json["start_date"] = start_date
     return valid_contract_json
+
+
+@pytest.fixture
+def end_date_before_start_date_contract_querydict(
+    end_date_before_start_date_contract_json
+):
+    qdict = QueryDict("", mutable=True)
+    qdict.update(end_date_before_start_date_contract_json)
+    return qdict
 
 
 @pytest.fixture
@@ -107,6 +124,13 @@ def start_date_day_incorrect_contract_json(valid_contract_json):
 
 
 @pytest.fixture
+def start_date_day_incorrect_contract_querydict(start_date_day_incorrect_contract_json):
+    qdict = QueryDict("", mutable=True)
+    qdict.update(start_date_day_incorrect_contract_json)
+    return qdict
+
+
+@pytest.fixture
 def end_date_day_incorrect_contract_json(valid_contract_json):
     end_date = datetime.date(2019, 1, 22)
     valid_contract_json["end_date"] = end_date
@@ -114,10 +138,24 @@ def end_date_day_incorrect_contract_json(valid_contract_json):
 
 
 @pytest.fixture
+def end_date_day_incorrect_contract_querydict(end_date_day_incorrect_contract_json):
+    qdict = QueryDict("", mutable=True)
+    qdict.update(end_date_day_incorrect_contract_json)
+    return qdict
+
+
+@pytest.fixture
 def negative_hours_contract_json(valid_contract_json):
     hours = -20.0
     valid_contract_json["hours"] = hours
     return valid_contract_json
+
+
+@pytest.fixture
+def negative_hours_contract_querydict(negative_hours_contract_json):
+    qdict = QueryDict("", mutable=True)
+    qdict.update(negative_hours_contract_json)
+    return qdict
 
 
 @pytest.fixture
@@ -217,3 +255,10 @@ def invalid_uuid_contract_patch_endpoint(contract_object):
         "modified_by": random_uuid,
     }
     return _dict
+
+
+@pytest.fixture
+def plain_request_object(user_object):
+    request = APIRequestFactory().get(reverse("user-me"), data=QueryDict())
+    force_authenticate(request, user=user_object)
+    return Request(request)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -205,3 +205,15 @@ def db_creation_contracts_list_endpoint(
 def invalid_uuid_contract_put_endpoint(invalid_uuid_contract_json, contract_object):
     invalid_uuid_contract_json["id"] = contract_object.id
     return invalid_uuid_contract_json
+
+
+@pytest.fixture
+def invalid_uuid_contract_patch_endpoint(contract_object):
+    random_uuid = uuid.uuid4()
+    _dict = {
+        "id": contract_object.id,
+        "user": random_uuid,
+        "created_by": random_uuid,
+        "modified_by": random_uuid,
+    }
+    return _dict

--- a/api/tests/test_serializers.py
+++ b/api/tests/test_serializers.py
@@ -1,0 +1,41 @@
+import pytest
+from rest_framework import serializers
+from api.serializers import ContractSerializer
+import pprint
+from pytz import datetime
+
+
+class TestContractSerializerValidation:
+    @pytest.mark.django_db
+    def test_validate_correct_data(self, valid_contract_json):
+        ContractSerializer(data=valid_contract_json).is_valid(raise_exception=True)
+
+    @pytest.mark.django_db
+    def test_start_date_causality_validation(
+        self, end_date_before_start_date_contract_json
+    ):
+        with pytest.raises(serializers.ValidationError) as e_info:
+            ContractSerializer(data=end_date_before_start_date_contract_json).is_valid(
+                raise_exception=True
+            )
+
+    @pytest.mark.django_db
+    def test_start_date_day_validation(self, start_date_day_incorrect_contract_json):
+        with pytest.raises(serializers.ValidationError) as e_info:
+            ContractSerializer(data=start_date_day_incorrect_contract_json).is_valid(
+                raise_exception=True
+            )
+
+    @pytest.mark.django_db
+    def test_end_date_day_validation(self, end_date_day_incorrect_contract_json):
+        with pytest.raises(serializers.ValidationError) as e_info:
+            ContractSerializer(data=end_date_day_incorrect_contract_json).is_valid(
+                raise_exception=True
+            )
+
+    @pytest.mark.django_db
+    def test_negative_hours_validation(self, negative_hours_contract_json):
+        with pytest.raises(serializers.ValidationError) as e_info:
+            ContractSerializer(data=negative_hours_contract_json).is_valid(
+                raise_exception=True
+            )

--- a/api/tests/test_serializers.py
+++ b/api/tests/test_serializers.py
@@ -7,35 +7,49 @@ from pytz import datetime
 
 class TestContractSerializerValidation:
     @pytest.mark.django_db
-    def test_validate_correct_data(self, valid_contract_json):
-        ContractSerializer(data=valid_contract_json).is_valid(raise_exception=True)
+    def test_validate_correct_data(
+        self, valid_contract_querydict, plain_request_object
+    ):
+        ContractSerializer(
+            data=valid_contract_querydict, context={"request": plain_request_object}
+        ).is_valid(raise_exception=True)
 
     @pytest.mark.django_db
     def test_start_date_causality_validation(
-        self, end_date_before_start_date_contract_json
+        self, end_date_before_start_date_contract_querydict, plain_request_object
     ):
         with pytest.raises(serializers.ValidationError) as e_info:
-            ContractSerializer(data=end_date_before_start_date_contract_json).is_valid(
-                raise_exception=True
-            )
+            ContractSerializer(
+                data=end_date_before_start_date_contract_querydict,
+                context={"request": plain_request_object},
+            ).is_valid(raise_exception=True)
 
     @pytest.mark.django_db
-    def test_start_date_day_validation(self, start_date_day_incorrect_contract_json):
+    def test_start_date_day_validation(
+        self, start_date_day_incorrect_contract_querydict, plain_request_object
+    ):
         with pytest.raises(serializers.ValidationError) as e_info:
-            ContractSerializer(data=start_date_day_incorrect_contract_json).is_valid(
-                raise_exception=True
-            )
+            ContractSerializer(
+                data=start_date_day_incorrect_contract_querydict,
+                context={"request": plain_request_object},
+            ).is_valid(raise_exception=True)
 
     @pytest.mark.django_db
-    def test_end_date_day_validation(self, end_date_day_incorrect_contract_json):
+    def test_end_date_day_validation(
+        self, end_date_day_incorrect_contract_querydict, plain_request_object
+    ):
         with pytest.raises(serializers.ValidationError) as e_info:
-            ContractSerializer(data=end_date_day_incorrect_contract_json).is_valid(
-                raise_exception=True
-            )
+            ContractSerializer(
+                data=end_date_day_incorrect_contract_querydict,
+                context={"request": plain_request_object},
+            ).is_valid(raise_exception=True)
 
     @pytest.mark.django_db
-    def test_negative_hours_validation(self, negative_hours_contract_json):
+    def test_negative_hours_validation(
+        self, negative_hours_contract_querydict, plain_request_object
+    ):
         with pytest.raises(serializers.ValidationError) as e_info:
-            ContractSerializer(data=negative_hours_contract_json).is_valid(
-                raise_exception=True
-            )
+            ContractSerializer(
+                data=negative_hours_contract_querydict,
+                context={"request": plain_request_object},
+            ).is_valid(raise_exception=True)

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -1,16 +1,12 @@
 # View tests come here
 
 import pytest
-import requests
-from django.urls import reverse
-
 import json
-import jwt
-from django.conf import settings
+
+from django.urls import reverse
 from rest_framework import status
-from pytz import datetime
-from api.models import Contract, User
-from rest_framework.test import RequestsClient
+
+from api.models import Contract
 
 
 class TestContractApiEndpoint:

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -11,8 +11,14 @@ from api.models import Contract
 
 
 class TestContractApiEndpoint:
-    def test_list_not_allowed(self, client):
-        response = client.get("http://localhost:8000/api/contracts/")
+    def test_list_forbidden_without_jwt(self, client):
+        response = client.get(path="http://localhost:8000/api/contracts/")
+        assert response.status_code == 401
+
+    @pytest.mark.django_db
+    def test_list_not_allowed(self, client, user_object_jwt):
+        client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
+        response = client.get(path="http://localhost:8000/api/contracts/")
         assert response.status_code == 501
 
     @pytest.mark.django_db
@@ -26,12 +32,8 @@ class TestContractApiEndpoint:
         :param user_object:
         :return:
         """
-
-        response = client.post(
-            path="/api/contracts/",
-            data=invalid_uuid_contract_json,
-            header="Authorization: Bearer {}".format(user_object_jwt),
-        )
+        client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
+        response = client.post(path="/api/contracts/", data=invalid_uuid_contract_json)
 
         content = json.loads(response.content)
 

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -144,7 +144,7 @@ class TestContractApiEndpoint:
             data=invalid_uuid_contract_put_endpoint,
         )
         content = json.loads(response.content)
-
+        print(content)
         assert response.status_code == 200
         # Check that neither "user", "created_by" nor "modified_by" changed from the originial/issuing user
         user_id = user_object.id

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -154,3 +154,37 @@ class TestContractApiEndpoint:
         assert contract.modified_by.id == user_id
         #      New Datetime           Old Datetime  --> Result should be positive
         assert contract.modified_at > contract_object.modified_at
+
+    @pytest.mark.django_db
+    def test_patch_uuid_contract(
+        self,
+        client,
+        invalid_uuid_contract_patch_endpoint,
+        contract_object,
+        user_object,
+        user_object_jwt,
+    ):
+        """
+        Test that trying to patch 'user, 'created_by' and 'mdofied_by' does not work.
+        Updating other values do not need to be tested here.
+        :param client:
+        :param invalid_uuid_contract_patch_endpoint:
+        :param contract_object:
+        :param user_object:
+        :param user_obejct_jwt:
+        :return:
+        """
+        client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
+        response = client.patch(
+            path=reverse("api:contracts-detail", args=[contract_object.id]),
+            data=invalid_uuid_contract_patch_endpoint,
+        )
+        contract = Contract.objects.get(id=contract_object.id)
+        user_id = user_object.id
+        assert response.status_code == 200
+
+        assert contract.user.id == user_id
+        assert contract.created_by.id == user_id
+        assert contract.modified_by.id == user_id
+        #      New Datetime           Old Datetime  --> Result should be positive
+        assert contract.modified_at > contract_object.modified_at

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -63,6 +63,14 @@ class TestContractApiEndpoint:
         assert response.status_code == 401
 
     @pytest.mark.django_db
+    def test_put_forbidden_without_jwt(self, client, valid_contract_json):
+
+        response = client.put(
+            path="http://localhost:8000/api/contracts/", data=valid_contract_json
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.django_db
     def test_list_objects_of_request_user(
         self, client, user_object, user_object_jwt, db_creation_contracts_list_endpoint
     ):
@@ -96,6 +104,7 @@ class TestContractApiEndpoint:
         :param user_object:
         :return:
         """
+
         client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
         response = client.post(path="/api/contracts/", data=invalid_uuid_contract_json)
 

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -1,3 +1,45 @@
 # View tests come here
 
 import pytest
+import requests
+from django.urls import reverse
+
+import json
+from rest_framework import status
+
+from api.models import Contract
+
+
+class TestContractApiEndpoint:
+    def test_list_not_allowed(self, client):
+        response = client.get("http://localhost:8000/api/contracts/")
+        assert response.status_code == 501
+
+    @pytest.mark.django_db
+    def test_create_with_correct_user(
+        self, client, invalid_uuid_contract_json, user_object, user_object_jwt
+    ):
+        """
+        The invalid uuid_contrac_json includes provided data for 'user', 'created_by' and 'modified_by'
+        which shall be set to the user-id provided within the JWT of the request.
+        :param invalid_uuid_contract_json:
+        :param user_object:
+        :return:
+        """
+
+        assert user_object_jwt
+
+        response = client.post(
+            path="/api/contracts/",
+            data=invalid_uuid_contract_json,
+            header="Authorization: Bearer {}".format(user_object_jwt),
+        )
+
+        content = json.loads(response.content)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        new_contract = Contract.objects.get(id=content["id"])
+
+        assert new_contract.user.id == user_object.id
+        assert new_contract.created_by.id == user_object.id
+        assert new_contract.created_by.id == user_object.id

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -20,14 +20,13 @@ class TestContractApiEndpoint:
         self, client, invalid_uuid_contract_json, user_object, user_object_jwt
     ):
         """
-        The invalid uuid_contrac_json includes provided data for 'user', 'created_by' and 'modified_by'
-        which shall be set to the user-id provided within the JWT of the request.
+        The invalid uuid_contract_json includes provided data for 'user', 'created_by' and 'modified_by'.
+        which is set to the user ID from the JWT of the request.
         :param invalid_uuid_contract_json:
         :param user_object:
         :return:
         """
 
-        assert user_object_jwt
 
         response = client.post(
             path="/api/contracts/",

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -5,14 +5,65 @@ import requests
 from django.urls import reverse
 
 import json
+import jwt
+from django.conf import settings
 from rest_framework import status
-
-from api.models import Contract
+from pytz import datetime
+from api.models import Contract, User
+from rest_framework.test import RequestsClient
 
 
 class TestContractApiEndpoint:
+    @pytest.mark.django_db
+    def test_get_only_own_contract(
+        self, client, user_object_jwt, diff_user_contract_object
+    ):
+        """
+        Test that attempting to retrieve a contract, which does not belong to the User requesting it,
+        gives a 404 response.
+        :param client:
+        :param user_object_jwt:
+        :param diff_user_contract_object:
+        :return:
+        """
+        client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
+        response = client.get(
+            path=reverse("api:contracts-detail", args=[diff_user_contract_object.id])
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.django_db
+    def test_get_forbidden_without_jwt(self, client, contract_object):
+        """
+        Test the detail Endpoint returns a 401 if no JWT is present.
+        :param client:
+        :param contract_object:
+        :param user_object:
+        :return:
+        """
+        response = client.get(path=r"/api/contracts/", args=[contract_object.id])
+        assert response.status_code == 401
+
     def test_list_forbidden_without_jwt(self, client):
+        """
+        Test the list endpoint returns a 401 if no JWT is present.
+        :param client:
+        :return:
+        """
         response = client.get(path="http://localhost:8000/api/contracts/")
+        assert response.status_code == 401
+
+    @pytest.mark.django_db
+    def test_create_forbidden_without_jwt(self, client, valid_contract_json):
+        """
+        Test the create endpoint returns a 401 if no JWT is present
+        :param client:
+        :param valid_contract_json:
+        :return:
+        """
+        response = client.post(
+            path="http://localhost:8000/api/contracts/", data=valid_contract_json
+        )
         assert response.status_code == 401
 
     @pytest.mark.django_db
@@ -20,7 +71,7 @@ class TestContractApiEndpoint:
         self, client, user_object, user_object_jwt, db_creation_contracts_list_endpoint
     ):
         """
-        We test that the list-endpoint only retrieves the Contracts of the User who issues the request.
+        Test that the list-endpoint only retrieves the Contracts of the User who issues the request.
         :param client:
         :param user_object:
         :param user_object_jwt:
@@ -32,7 +83,6 @@ class TestContractApiEndpoint:
         client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
         response = client.get(path="http://localhost:8000/api/contracts/")
         data = json.loads(response.content)
-        print(data)
         assert response.status_code == 200
         assert all(
             Contract.objects.get(id=contract["id"]).user.id == user_object.id
@@ -44,8 +94,8 @@ class TestContractApiEndpoint:
         self, client, invalid_uuid_contract_json, user_object, user_object_jwt
     ):
         """
-        The invalid uuid_contract_json includes provided data for 'user', 'created_by' and 'modified_by'.
-        which is set to the user ID from the JWT of the request.
+        Test that 'user', 'created_by' and 'modified_by' (incorrectly set invalid_uuid_contract_json)
+        are set to the user_id from the JWT of the request.
         :param invalid_uuid_contract_json:
         :param user_object:
         :return:

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -16,10 +16,28 @@ class TestContractApiEndpoint:
         assert response.status_code == 401
 
     @pytest.mark.django_db
-    def test_list_not_allowed(self, client, user_object_jwt):
+    def test_list_objects_of_request_user(
+        self, client, user_object, user_object_jwt, db_creation_contracts_list_endpoint
+    ):
+        """
+        We test that the list-endpoint only retrieves the Contracts of the User who issues the request.
+        :param client:
+        :param user_object:
+        :param user_object_jwt:
+        :param create_n_user_objects:
+        :param create_n_contract_objects:
+        :return:
+        """
+
         client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
         response = client.get(path="http://localhost:8000/api/contracts/")
-        assert response.status_code == 501
+        data = json.loads(response.content)
+        print(data)
+        assert response.status_code == 200
+        assert all(
+            Contract.objects.get(id=contract["id"]).user.id == user_object.id
+            for contract in data
+        )
 
     @pytest.mark.django_db
     def test_create_with_correct_user(

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -27,7 +27,6 @@ class TestContractApiEndpoint:
         :return:
         """
 
-
         response = client.post(
             path="/api/contracts/",
             data=invalid_uuid_contract_json,

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -40,6 +40,7 @@ class TestContractApiEndpoint:
         response = client.get(path=r"/api/contracts/", args=[contract_object.id])
         assert response.status_code == 401
 
+    @pytest.mark.django_db
     def test_list_forbidden_without_jwt(self, client):
         """
         Test the list endpoint returns a 401 if no JWT is present.

--- a/api/urls.py
+++ b/api/urls.py
@@ -4,9 +4,9 @@ from rest_framework.routers import DefaultRouter
 
 from api.views import index, ContractViewSet
 
-
+app_name = "api"
 router = DefaultRouter()
-router.register(r"contracts", ContractViewSet)
+router.register(r"contracts", ContractViewSet, base_name="contracts")
 
 urlpatterns = [
     # Demonstration url for celery

--- a/api/urls.py
+++ b/api/urls.py
@@ -2,11 +2,11 @@ from django.urls import path, include
 from django.conf.urls import url
 from rest_framework.routers import DefaultRouter
 
-from api.views import index
+from api.views import index, ContractViewSet
 
 
 router = DefaultRouter()
-
+router.register(r"contracts", ContractViewSet)
 
 urlpatterns = [
     # Demonstration url for celery

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,5 +1,4 @@
 from django.urls import path, include
-from django.conf.urls import url
 from rest_framework.routers import DefaultRouter
 
 from api.views import index, ContractViewSet

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,9 +1,15 @@
-from django.urls import path
+from django.urls import path, include
 from django.conf.urls import url
+from rest_framework.routers import DefaultRouter
 
 from api.views import index
 
+
+router = DefaultRouter()
+
+
 urlpatterns = [
     # Demonstration url for celery
-    path("celery-dummy", index, name="index")
+    path("celery-dummy", index, name="index"),
+    path("", include(router.urls)),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponse
-from rest_framework import mixins, status, viewsets
+from rest_framework import status, viewsets
 from rest_framework.response import Response
-from api.tasks import twenty_second_task, async_5_user_creation
+from api.tasks import async_5_user_creation
 
 from api.models import Contract
 

--- a/api/views.py
+++ b/api/views.py
@@ -26,7 +26,7 @@ class ContractViewSet(viewsets.ModelViewSet):
         return Response(status=status.HTTP_501_NOT_IMPLEMENTED)
 
     def create(self, request, *args, **kwargs):
-        jwt_token = request.META.get("header").split()[-1]
+        jwt_token = request.META.get("HTTP_AUTHORIZATION").split()[-1]
         user_id = jwt.decode(
             jwt_token, os.environ.get("DJANGO_SECRET_KEY"), algorithm="HS256"
         )["user_id"]

--- a/api/views.py
+++ b/api/views.py
@@ -20,8 +20,9 @@ class ContractViewSet(viewsets.ModelViewSet):
     serializer_class = ContractSerializer
     name = "contracts"
 
-    def list(self, request, *args, **kwargs):
-        return Response(status=status.HTTP_501_NOT_IMPLEMENTED)
+    def get_queryset(self):
+        queryset = super(ContractViewSet, self).get_queryset()
+        return queryset.filter(user__id=self.request.user_id)
 
     def create(self, request, *args, **kwargs):
         user_id = request.user_id

--- a/api/views.py
+++ b/api/views.py
@@ -1,6 +1,5 @@
 import jwt
 import os
-import config.settings.local as lc
 from django.http import HttpResponse
 from rest_framework import mixins, status, viewsets
 from rest_framework.response import Response

--- a/api/views.py
+++ b/api/views.py
@@ -20,20 +20,23 @@ class ContractViewSet(viewsets.ModelViewSet):
     serializer_class = ContractSerializer
     name = "contracts"
 
-    def get_queryset(self):
-        queryset = super(ContractViewSet, self).get_queryset()
-        return queryset.filter(user__id=self.request.user_id)
-
-    def create(self, request, *args, **kwargs):
+    def add_user_id(self, request):
         user_id = request.user_id
         data = request.data.dict()
         data["user"] = user_id
         data["created_by"] = user_id
         data["modified_by"] = user_id
-        serializer = self.get_serializer(data=data)
-        serializer.is_valid(raise_exception=True)
-        self.perform_create(serializer)
-        headers = self.get_success_headers(serializer.data)
-        return Response(
-            serializer.data, status=status.HTTP_201_CREATED, headers=headers
-        )
+        return data
+
+    def get_queryset(self):
+        queryset = super(ContractViewSet, self).get_queryset()
+        return queryset.filter(user__id=self.request.user_id)
+
+    def get_serializer(self, *args, **kwargs):
+        seri = super(ContractViewSet, self).get_serializer(*args, **kwargs)
+        request = self.request
+        if request.method == "POST":
+            seri.initial_data = self.add_user_id(request)
+            return seri
+
+        return seri

--- a/api/views.py
+++ b/api/views.py
@@ -1,6 +1,16 @@
+import jwt
+import os
+import config.settings.local as lc
 from django.http import HttpResponse
+from rest_framework import viewsets
+from rest_framework import mixins
+from rest_framework import status
+from rest_framework.response import Response
 from api.tasks import twenty_second_task, async_5_user_creation
-import random
+
+from api.models import Contract
+
+from api.serializers import ContractSerializer
 
 # Proof of Concept that celery works
 
@@ -8,3 +18,30 @@ import random
 def index(request):
     async_5_user_creation.delay()
     return HttpResponse("A Dummy site.")
+
+
+class ContractViewSet(viewsets.ModelViewSet):
+    queryset = Contract.objects.all()
+    serializer_class = ContractSerializer
+    name = "contracts"
+
+    def list(self, request, *args, **kwargs):
+        return Response(status=status.HTTP_501_NOT_IMPLEMENTED)
+
+    def create(self, request, *args, **kwargs):
+        jwt_token = request.META.get("header").split()[-1]
+        user_id = jwt.decode(
+            jwt_token, os.environ.get("DJANGO_SECRET_KEY"), algorithm="HS256"
+        )["user_id"]
+
+        data = request.data.dict()
+        data["user"] = user_id
+        data["created_by"] = user_id
+        data["modified_by"] = user_id
+        serializer = self.get_serializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        return Response(
+            serializer.data, status=status.HTTP_201_CREATED, headers=headers
+        )

--- a/api/views.py
+++ b/api/views.py
@@ -1,5 +1,3 @@
-import jwt
-import os
 from django.http import HttpResponse
 from rest_framework import mixins, status, viewsets
 from rest_framework.response import Response
@@ -26,11 +24,7 @@ class ContractViewSet(viewsets.ModelViewSet):
         return Response(status=status.HTTP_501_NOT_IMPLEMENTED)
 
     def create(self, request, *args, **kwargs):
-        jwt_token = request.META.get("HTTP_AUTHORIZATION").split()[-1]
-        user_id = jwt.decode(
-            jwt_token, os.environ.get("DJANGO_SECRET_KEY"), algorithm="HS256"
-        )["user_id"]
-
+        user_id = request.user_id
         data = request.data.dict()
         data["user"] = user_id
         data["created_by"] = user_id

--- a/api/views.py
+++ b/api/views.py
@@ -2,9 +2,7 @@ import jwt
 import os
 import config.settings.local as lc
 from django.http import HttpResponse
-from rest_framework import viewsets
-from rest_framework import mixins
-from rest_framework import status
+from rest_framework import mixins, status, viewsets
 from rest_framework.response import Response
 from api.tasks import twenty_second_task, async_5_user_creation
 

--- a/api/views.py
+++ b/api/views.py
@@ -20,31 +20,6 @@ class ContractViewSet(viewsets.ModelViewSet):
     serializer_class = ContractSerializer
     name = "contracts"
 
-    def add_user_id(self, serializer):
-        user_id = self.request.user_id
-        data = serializer.initial_data.dict()
-        data["user"] = user_id
-        data["created_by"] = user_id
-        data["modified_by"] = user_id
-        return data
-
     def get_queryset(self):
         queryset = super(ContractViewSet, self).get_queryset()
         return queryset.filter(user__id=self.request.user_id)
-
-    def get_serializer(self, *args, **kwargs):
-        seri = super(ContractViewSet, self).get_serializer(*args, **kwargs)
-        request = self.request
-        if request.method in ["POST", "PUT"]:
-            seri.initial_data = self.add_user_id(seri)
-            return seri
-
-        if request.method == "PATCH":
-            # Not allowed keys "user" and "created_by" in a PATCH-Request.
-            # Set "modified_by" to the user issuing the request
-            seri.initial_data.pop("user", None)
-            seri.initial_data.pop("created_by", None)
-            seri.initial_data["modified_by"] = request.user_id
-            return seri
-
-        return seri

--- a/api/views.py
+++ b/api/views.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponse
 from rest_framework import status, viewsets
 from rest_framework.response import Response
+from rest_framework.generics import get_object_or_404
 from api.tasks import async_5_user_creation
 
 from api.models import Contract
@@ -22,4 +23,4 @@ class ContractViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         queryset = super(ContractViewSet, self).get_queryset()
-        return queryset.filter(user__id=self.request.user_id)
+        return queryset.filter(user__id=self.request.user.id)

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -95,7 +95,7 @@ AUTH_USER_MODEL = "api.User"
 SIMPLE_JWT = {"ALGORITHM": "HS256", "SIGNING_KEY": env.str("DJANGO_SECRET_KEY")}
 
 REST_FRAMEWORK = {
-    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
+    "DEFAULT_PERMISSION_CLASSES": ("api.permissions.AccessOwnDataPermission",),
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     ),

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -91,6 +91,9 @@ AUTH_PASSWORD_VALIDATORS = [
 
 AUTH_USER_MODEL = "api.User"
 
+# Simple_JWT
+SIMPLE_JWT = {"ALGORITHM": "HS256", "SIGNING_KEY": env.str("DJANGO_SECRET_KEY")}
+
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework_simplejwt.authentication.JWTAuthentication",

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -95,9 +95,10 @@ AUTH_USER_MODEL = "api.User"
 SIMPLE_JWT = {"ALGORITHM": "HS256", "SIGNING_KEY": env.str("DJANGO_SECRET_KEY")}
 
 REST_FRAMEWORK = {
+    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework_simplejwt.authentication.JWTAuthentication",
-    )
+    ),
 }
 
 DJOSER = {"TOKEN_MODEL": None}

--- a/config/urls.py
+++ b/config/urls.py
@@ -22,6 +22,6 @@ urlpatterns = [
     url(r"^api/", include("api.urls"), name="api"),
     url(r"^api/", include("api-docs.api_docs"), name="api_docs"),
     url(r"^admin/", admin.site.urls),
-    url(r"^auth/", include("djoser.urls")),
+    url(r"^auth/", include("djoser.urls"), name="djoser-auth"),
     url(r"^auth/", include("djoser.urls.jwt")),
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - POSTGRES_PORT=5432
       - DJANGO_SETTINGS_MODULE=config.settings.local
       - RABBITMQ_URL=amqp://broker_adm:broker_pass@rabbit_broker:5672/
-      - DJANGO_SECRET_KEY=h18i_1j3^d$e6iq8xur&yvbkpk08il9x^&9cf2l2%-0yqx7ss)
+      - DJANGO_SECRET_KEY=h18i_1j3^d1e6iq8xur&yvbkpk08il9x^&9cf2l2%-0yqx7ss)
     volumes:
       - .:/app
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - POSTGRES_PORT=5432
       - DJANGO_SETTINGS_MODULE=config.settings.local
       - RABBITMQ_URL=amqp://broker_adm:broker_pass@rabbit_broker:5672/
+      - DJANGO_SECRET_KEY=h18i_1j3^d$e6iq8xur&yvbkpk08il9x^&9cf2l2%-0yqx7ss)
     volumes:
       - .:/app
     depends_on:


### PR DESCRIPTION
In diesem PR werden folgende Änderungen bemacht:

- [x]  ContractSerializer implementieren
- [ ] Contract API Endpoint
    - [x]  List-endpoint gibt nur Objekte die dem anfragenden User gehören zurück, sonst 404
    - [x]  Retrieve-endpoint soll das Objekt nur zurückgeben falls es dem anfragenden User gehört, sonst 404
    - [x]  Create-Endpoint soll die JSON-Daten für `user`, `modified_by` und `created_by` mit der ID aus dem JWT überschreiben.
    - [x]  PUT und PATCH Endpoint sollen  JSON-Daten für `user`, `modified_by` und `created_by` mit der ID aus dem JWT überschreiben bzw. aus den Daten entfernen (Patch)
    - [ ]  `contracts/<pk>/shifts` endpoint soll alle `Shift` Objekte zurückgeben die zu dem `Contract` Objekt gehören sofern es dem anfragenden User gehört, sonst 404

- [x] Tests für obige Methoden
