### PR TITLE
Finish Contract API Endpoint

### DIFF
--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -205,6 +205,26 @@ class TestContractApiEndpoint:
         #      New Datetime           Old Datetime  --> Result should be positive
         assert contract.modified_at > contract_object.modified_at
 
+    @pytest.mark.django_db
+    def test_shifts_action_contract(
+        self,
+        client,
+        user_object_jwt,
+        user_object,
+        contract_object,
+        db_creation_shifts_list_endpoint,
+    ):
+
+        client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
+        response = client.get(
+            path=reverse("api:contracts-shifts", args=[contract_object.id])
+        )
+
+        content = json.loads(response.content)
+
+        assert len(content) == 2  # We created only 2 shifts for the User
+        assert all(shift["contract"] == str(contract_object.id) for shift in content)
+
 
 class TestShiftApiEndpoint:
     @pytest.mark.django_db

--- a/api/views.py
+++ b/api/views.py
@@ -20,11 +20,18 @@ def index(request):
 class ContractViewSet(viewsets.ModelViewSet):
     queryset = Contract.objects.all()
     serializer_class = ContractSerializer
+
     name = "contracts"
 
     def get_queryset(self):
         queryset = super(ContractViewSet, self).get_queryset()
         return queryset.filter(user__id=self.request.user.id)
+
+    @action(detail=True, url_name="shifts", url_path="shifts", methods=["get"])
+    def get_shifts_list(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = ShiftSerializer(instance.shifts, many=True)
+        return Response(serializer.data)
 
 
 class ShiftViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
Es ist der letzte Punkt des PR #17 abzuarbeiten :

- [x] `contracts/<pk>/shifts` endpoint soll alle `Shift` Objekte zurückgeben die zu dem `Contract` Objekt gehören sofern es dem anfragenden User gehört, sonst 404