### PR TITLE
Report api

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -221,8 +221,8 @@ class ReportSerializer(RestrictModificationModelSerializer):
         fields = "__all__"
         extra_kwargs = {
             # Will be set automatically by the Model
-            "created_at": {"required": False, "write_only": True},
-            "modified_at": {"required": False, "write_only": True},
+            "created_at": {"required": False},
+            "modified_at": {"required": False},
             "created_by": {"write_only": True},
             "modified_by": {"write_only": True},
             "user": {"write_only": True},

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -2,8 +2,7 @@ import json
 
 from rest_framework import serializers
 from calendar import monthrange
-from api.models import Contract, Shift
-from rest_framework.request import QueryDict
+from api.models import Contract, Shift, Report
 
 
 class TagsSerializerField(serializers.Field):
@@ -214,3 +213,17 @@ class ShiftSerializer(RestrictModificationModelSerializer):
             assert isinstance(tags, list)
             updated_object.tags.set(*tags)
         return updated_object
+
+
+class ReportSerializer(RestrictModificationModelSerializer):
+    class Meta:
+        model = Report
+        fields = "__all__"
+        extra_kwargs = {
+            # Will be set automatically by the Model
+            "created_at": {"required": False, "write_only": True},
+            "modified_at": {"required": False, "write_only": True},
+            "created_by": {"write_only": True},
+            "modified_by": {"write_only": True},
+            "user": {"write_only": True},
+        }

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -2,3 +2,4 @@ from api.tests.conftest_files.general_conftest import *
 from api.tests.conftest_files.contract_conftest import *
 from api.tests.conftest_files.user_conftest import *
 from api.tests.conftest_files.shift_conftest import *
+from api.tests.conftest_files.report_conftest import *

--- a/api/tests/conftest_files/report_conftest.py
+++ b/api/tests/conftest_files/report_conftest.py
@@ -1,0 +1,49 @@
+import pytest
+from pytz import datetime
+
+from api.models import Report
+
+
+@pytest.fixture
+def create_n_report_objects():
+    month_year = datetime.date(2019, 1, 1)
+    hours = datetime.timedelta(0)
+    created_at = datetime.datetime(2019, 1, 1, 16).isoformat()
+    modified_at = created_at
+
+    def create_reports(start_stop, user, contract, month_year=month_year):
+        lst = []
+        for i in range(*start_stop):
+            report = Report.objects.create(
+                month_year=month_year,
+                hours=hours,
+                contract=contract,
+                user=user,
+                created_by=user,
+                modified_by=user,
+                created_at=created_at,
+                modified_at=modified_at,
+            )
+            lst.append(report)
+
+        return lst
+
+    return create_reports
+
+
+@pytest.fixture
+def report_object(create_n_report_objects, user_object, contract_object):
+    return create_n_report_objects((1,), user_object, contract_object)[0]
+
+
+@pytest.fixture
+def db_get_current_endpoint(
+    create_n_report_objects, user_object, contract_object, report_object
+):
+    # create 2 more Reports for February and March
+    create_n_report_objects(
+        (1,), user_object, contract_object, month_year=datetime.date(2019, 2, 1)
+    )
+    create_n_report_objects(
+        (1,), user_object, contract_object, month_year=datetime.date(2019, 3, 1)
+    )

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -3,9 +3,11 @@
 import pytest
 import json
 
+
 from django.urls import reverse
 from rest_framework import status
 from datetime import datetime
+from freezegun import freeze_time
 
 
 from api.models import Contract, Shift
@@ -313,3 +315,16 @@ class TestShiftApiEndpoint:
             and datetime.strptime(i["started"], "%Y-%m-%dT%H:%M:%SZ").year == 2019
             for i in data
         )
+
+
+class TestReportApiEndpoint:
+    @freeze_time("2019-01-10")
+    @pytest.mark.django_db
+    def test_get_current_endpoint(
+        self, client, user_object_jwt, db_get_current_endpoint
+    ):
+        client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
+        response = client.get(path=reverse("api:reports-get_current"))
+        content = json.loads(response.content)
+
+        assert content["month_year"] == "2019-01-01"

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,12 +1,13 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 
-from api.views import index, ContractViewSet, ShiftViewSet
+from api.views import index, ContractViewSet, ShiftViewSet, ReportViewSet
 
 app_name = "api"
 router = DefaultRouter()
 router.register(r"contracts", ContractViewSet, base_name="contracts")
 router.register(r"shifts", ShiftViewSet, base_name="shifts")
+router.register(r"reports", ReportViewSet, base_name="reports")
 
 list_month_year_shifts = ShiftViewSet.as_view({"get": "list_month_year"})
 


### PR DESCRIPTION
In diesem PR werden folgende Änderungen gemacht:

- [x] ReportSerilaizer implementieren

- [x] Report API Endpoint (`ReadOnlyViewSet`)
    - [x]  List-endpoint gibt nur Objekte die dem anfragenden User gehören zurück, sonst 404
    - [x] Retrieve-endpoint soll das Objekt nur zurückgeben falls es dem anfragenden User gehört, sonst 404
    - [x]  `reports/get_current` soll das Report Objekt des momentanen Monats ausgeben, sonst 404

- [x] Tests für obige Methoden