### PR TITLE
Add DJANGO_SECRET_KEY to celery_worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - POSTGRES_PORT=5432
       - RABBITMQ_URL=amqp://broker_adm:broker_pass@rabbit_broker:5672/
       - DJANGO_SETTINGS_MODULE=config.settings.local
+      - DJANGO_SECRET_KEY=h18i_1j3^d1e6iq8xur&yvbkpk08il9x^&9cf2l2%-0yqx7ss)
     volumes:
       - .:/app
     links:


### PR DESCRIPTION
`docker-compose up` won't run without the `DJANGO_SECRET_KEY`.