### PR TITLE
Make JSON requests work

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -36,7 +36,7 @@ class RestrictModificationModelSerializer(serializers.ModelSerializer):
 
     def to_internal_value(self, data):
         request = self.context["request"]
-        data = data.dict()
+
         if request.method in ["POST", "PUT"]:
             data = self.add_user_id(request, data)
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -16,7 +16,7 @@ class TagsSerializerField(serializers.Field):
         return list(map(lambda x: x.name, obj.all()))
 
     def to_internal_value(self, data):
-        return json.loads(data)
+        return data
 
 
 class RestrictModificationModelSerializer(serializers.ModelSerializer):

--- a/api/tests/conftest_files/contract_conftest.py
+++ b/api/tests/conftest_files/contract_conftest.py
@@ -22,7 +22,7 @@ def valid_contract_json(user_object):
     hours = 20.0
     start_date = datetime.date(2019, 1, 1).isoformat()
     end_date = datetime.date(2019, 1, 31).isoformat()
-    user = user_object.id
+    user = str(user_object.id)
 
     created_at = datetime.datetime(2018, 12, 31, hour=10).isoformat()
     modified_at = created_at
@@ -164,7 +164,7 @@ def invalid_uuid_contract_json(valid_contract_json):
     :param valid_contract_json:
     :return: Dict
     """
-    random_uuid = uuid.uuid4()
+    random_uuid = str(uuid.uuid4())
     valid_contract_json["user"] = random_uuid
     valid_contract_json["created_by"] = random_uuid
     valid_contract_json["modified_by"] = random_uuid
@@ -260,7 +260,7 @@ def invalid_uuid_contract_put_endpoint(invalid_uuid_contract_json, contract_obje
     :param contract_object:
     :return: Dict
     """
-    invalid_uuid_contract_json["id"] = contract_object.id
+    invalid_uuid_contract_json["id"] = str(contract_object.id)
     return invalid_uuid_contract_json
 
 
@@ -273,9 +273,9 @@ def invalid_uuid_contract_patch_endpoint(contract_object):
     :param contract_object:
     :return: Dict
     """
-    random_uuid = uuid.uuid4()
+    random_uuid = str(uuid.uuid4())
     _dict = {
-        "id": contract_object.id,
+        "id": str(contract_object.id),
         "user": random_uuid,
         "created_by": random_uuid,
         "modified_by": random_uuid,

--- a/api/tests/conftest_files/shift_conftest.py
+++ b/api/tests/conftest_files/shift_conftest.py
@@ -23,11 +23,11 @@ def valid_shift_json(user_object, contract_object):
     stopped = datetime.datetime(2019, 1, 29, 16, tzinfo=utc).isoformat()
     created_at = datetime.datetime(2019, 1, 29, 16, tzinfo=utc).isoformat()
     modified_at = created_at
-    user = user_object.id
-    contract = contract_object.id
+    user = str(user_object.id)
+    contract = str(contract_object.id)
     _type = "st"
     note = "something was strange"
-    tags = json.dumps(["tag1", "tag2"])
+    tags = ["tag1", "tag2"]
     was_reviewed = True
 
     data = {
@@ -117,7 +117,7 @@ def contract_not_belonging_to_user_json(valid_shift_json, diff_user_contract_obj
     :param diff_user_contract_object:
     :return:Dict
     """
-    valid_shift_json["contract"] = diff_user_contract_object.id
+    valid_shift_json["contract"] = str(diff_user_contract_object.id)
     return valid_shift_json
 
 
@@ -165,7 +165,7 @@ def tags_not_strings_json(valid_shift_json):
     :param valid_shift_json:
     :return: Dict
     """
-    valid_shift_json["tags"] = json.dumps([1, [], "a"])
+    valid_shift_json["tags"] = [1, [], "a"]
     return valid_shift_json
 
 
@@ -333,8 +333,8 @@ def put_new_tags_json(valid_shift_json, shift_object):
     :param shift_object:
     :return: Dict
     """
-    valid_shift_json["id"] = shift_object.id
-    valid_shift_json["tags"] = json.dumps(["new_tag1", "new_tag2"])
+    valid_shift_json["id"] = str(shift_object.id)
+    valid_shift_json["tags"] = ["new_tag1", "new_tag2"]
     return valid_shift_json
 
 
@@ -345,7 +345,7 @@ def patch_new_tags_json(shift_object):
     :param shift_object:
     :return: Dict
     """
-    _dict = {"id": shift_object.id, "tags": json.dumps(["new_tag1", "new_tag2"])}
+    _dict = {"id": str(shift_object.id), "tags": ["new_tag1", "new_tag2"]}
     return _dict
 
 
@@ -382,8 +382,7 @@ def db_creation_list_month_year_endpoint(
 def put_to_exported_shift_json(shift_object, valid_shift_json):
     shift_object.was_exported = True
     shift_object.save()
-    valid_shift_json["id"] = shift_object.id
-    valid_shift_json["tags"] = json.dumps(
-        ["new_tag1", "new_tag2"]
-    )  # tags just for example
+    valid_shift_json["id"] = str(shift_object.id)
+    valid_shift_json["tags"] = ["new_tag1", "new_tag2"]
+
     return valid_shift_json

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -40,7 +40,8 @@ class TestContractApiEndpoint:
         """
         client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
         response = client.get(
-            path=reverse("api:contracts-detail", args=[diff_user_contract_object.id])
+            path=reverse("api:contracts-detail", args=[diff_user_contract_object.id]),
+            content_type="application/json",
         )
         assert response.status_code == 404
 
@@ -53,7 +54,11 @@ class TestContractApiEndpoint:
         :param user_object:
         :return:
         """
-        response = client.get(path=r"/api/contracts/", args=[contract_object.id])
+        response = client.get(
+            path=r"/api/contracts/",
+            args=[contract_object.id],
+            content_type="application/json",
+        )
         assert response.status_code == 401
 
     @pytest.mark.django_db
@@ -63,7 +68,9 @@ class TestContractApiEndpoint:
         :param client:
         :return:
         """
-        response = client.get(path="http://localhost:8000/api/contracts/")
+        response = client.get(
+            path="http://localhost:8000/api/contracts/", content_type="application/json"
+        )
         assert response.status_code == 401
 
     @pytest.mark.django_db
@@ -75,7 +82,9 @@ class TestContractApiEndpoint:
         :return:
         """
         response = client.post(
-            path="http://localhost:8000/api/contracts/", data=valid_contract_json
+            path="http://localhost:8000/api/contracts/",
+            data=json.dumps(valid_contract_json),
+            content_type="application/json",
         )
         assert response.status_code == 401
 
@@ -89,7 +98,9 @@ class TestContractApiEndpoint:
         """
 
         response = client.put(
-            path="http://localhost:8000/api/contracts/", data=valid_contract_json
+            path="http://localhost:8000/api/contracts/",
+            data=json.dumps(valid_contract_json),
+            content_type="application/json",
         )
         assert response.status_code == 401
 
@@ -107,7 +118,9 @@ class TestContractApiEndpoint:
         """
 
         client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
-        response = client.get(path="http://localhost:8000/api/contracts/")
+        response = client.get(
+            path="http://localhost:8000/api/contracts/", content_type="application/json"
+        )
         data = json.loads(response.content)
         assert response.status_code == 200
         assert all(
@@ -138,7 +151,11 @@ class TestContractApiEndpoint:
         """
 
         client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
-        response = client.post(path="/api/contracts/", data=invalid_uuid_contract_json)
+        response = client.post(
+            path="/api/contracts/",
+            data=json.dumps(invalid_uuid_contract_json),
+            content_type="application/json",
+        )
 
         content = json.loads(response.content)
 
@@ -173,7 +190,8 @@ class TestContractApiEndpoint:
         client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
         response = client.put(
             path=reverse("api:contracts-detail", args=[contract_object.id]),
-            data=invalid_uuid_contract_put_endpoint,
+            data=json.dumps(invalid_uuid_contract_put_endpoint),
+            content_type="application/json",
         )
         content = json.loads(response.content)
 
@@ -209,7 +227,8 @@ class TestContractApiEndpoint:
         client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
         response = client.patch(
             path=reverse("api:contracts-detail", args=[contract_object.id]),
-            data=invalid_uuid_contract_patch_endpoint,
+            data=json.dumps(invalid_uuid_contract_patch_endpoint),
+            content_type="application/json",
         )
         contract = Contract.objects.get(id=contract_object.id)
         user_id = user_object.id
@@ -243,7 +262,8 @@ class TestContractApiEndpoint:
 
         client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
         response = client.get(
-            path=reverse("api:contracts-shifts", args=[contract_object.id])
+            path=reverse("api:contracts-shifts", args=[contract_object.id]),
+            content_type="application/json",
         )
 
         content = json.loads(response.content)
@@ -272,7 +292,11 @@ class TestContractApiEndpoint:
         :return:
         """
         client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
-        response = client.post(path="/api/contracts/", data=valid_contract_json)
+        response = client.post(
+            path="/api/contracts/",
+            data=json.dumps(valid_contract_json),
+            content_type="application/json",
+        )
 
         content = json.loads(response.content)
         start_date = (
@@ -298,7 +322,9 @@ class TestShiftApiEndpoint:
         """
 
         client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
-        response = client.get(path=reverse("api:shifts-list"))
+        response = client.get(
+            path=reverse("api:shifts-list"), content_type="application/json"
+        )
 
         data = json.loads(response.content)
         assert response.status_code == 200
@@ -319,12 +345,16 @@ class TestShiftApiEndpoint:
         :return:
         """
         client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
-        response = client.post(path=reverse("api:shifts-list"), data=valid_shift_json)
+        response = client.post(
+            path=reverse("api:shifts-list"),
+            data=json.dumps(valid_shift_json),
+            content_type="application/json",
+        )
         data = json.loads(response.content)
 
         assert response.status_code == 201
         shift_object = Shift.objects.get(pk=data["id"])
-        initial_tags = json.loads(valid_shift_json["tags"])
+        initial_tags = valid_shift_json["tags"]
 
         assert shift_object
         assert shift_object.tags.all().count() == len(initial_tags)
@@ -345,14 +375,14 @@ class TestShiftApiEndpoint:
         client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
         response = client.put(
             path=reverse("api:shifts-detail", args=[put_new_tags_json["id"]]),
-            data=put_new_tags_json,
+            data=json.dumps(put_new_tags_json),
+            content_type="application/json",
         )
-
         data = json.loads(response.content)
-        initial_tags = json.loads(put_new_tags_json["tags"])
-
+        print(data)
         assert response.status_code == 200
-        shift_object = Shift.objects.get(pk=put_new_tags_json["id"])
+        initial_tags = put_new_tags_json["tags"]
+        shift_object = Shift.objects.get(pk=data["id"])
         assert shift_object.tags.all().count() == len(initial_tags)
         assert all(
             shift_tag.name in initial_tags for shift_tag in shift_object.tags.all()
@@ -371,10 +401,11 @@ class TestShiftApiEndpoint:
         client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
         response = client.patch(
             path=reverse("api:shifts-detail", args=[patch_new_tags_json["id"]]),
-            data=patch_new_tags_json,
+            data=json.dumps(patch_new_tags_json),
+            content_type="application/json",
         )
 
-        initial_tags = json.loads(patch_new_tags_json["tags"])
+        initial_tags = patch_new_tags_json["tags"]
 
         assert response.status_code == 200
         shift_object = Shift.objects.get(pk=patch_new_tags_json["id"])
@@ -397,7 +428,10 @@ class TestShiftApiEndpoint:
         :return:
         """
         client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
-        response = client.get(path=reverse("api:list-shifts", args=[1, 2019]))
+        response = client.get(
+            path=reverse("api:list-shifts", args=[1, 2019]),
+            content_type="application/json",
+        )
 
         data = json.loads(response.content)
 
@@ -416,8 +450,10 @@ class TestShiftApiEndpoint:
         client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
         response = client.put(
             path=reverse("api:shifts-detail", args=[put_to_exported_shift_json["id"]]),
-            data=put_to_exported_shift_json,
+            data=json.dumps(put_to_exported_shift_json),
+            content_type="application/json",
         )
+        print(json.loads(response.content))
         assert response.status_code == 403
 
 
@@ -436,7 +472,9 @@ class TestReportApiEndpoint:
         :return:
         """
         client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
-        response = client.get(path=reverse("api:reports-get_current"))
+        response = client.get(
+            path=reverse("api:reports-get_current"), content_type="application/json"
+        )
         content = json.loads(response.content)
 
         assert content["month_year"] == "2019-01-01"

--- a/project_celery/tests/test_celery.py
+++ b/project_celery/tests/test_celery.py
@@ -10,7 +10,7 @@ from project_celery.celery import app
 
 
 class TestCeleryBeats:
-    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.django_db(transaction=True, reset_sequences=True)
     @freeze_time("2019-02-1")
     def test_start_of_month_report_creation(
         self, celery_test_fixture, user_object, contract_ending_in_february
@@ -39,7 +39,7 @@ class TestCeleryBeats:
             month_year=_month_year,
         )
 
-    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.django_db(transaction=True, reset_sequences=True)
     @freeze_time("2019-02-1")
     def test_start_of_month_report_creation_correct_hours(
         self,


### PR DESCRIPTION
Running a `POST` request to `/api/shifts/` will throw an error, because `data` might already be of instance `dict`.

## Request

```bash
curl --request POST \
  --url 'http://localhost:8000/api/shifts/?=' \
  --header 'authorization: Bearer <auth_token>' \
  --header 'content-type: application/json' \
  --data '{
  "started": "2019-06-02T12:30",
  "stopped": "2019-06-02T12:30",
  "contract": "<some_uuid>",
  "type": "st",
  "tags": "abc"
}'
```

## Error

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/django/contrib/staticfiles/handlers.py", line 65, in __call__
    return self.application(environ, start_response)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/wsgi.py", line 142, in __call__
    response = self.get_response(request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 78, in get_response
    response = self._middleware_chain(request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/exception.py", line 36, in inner
    response = response_for_exception(request, exc)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/exception.py", line 90, in response_for_exception
    response = handle_uncaught_exception(request, get_resolver(get_urlconf()), sys.exc_info())
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/exception.py", line 125, in handle_uncaught_exception
    return debug.technical_500_response(request, *exc_info)
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/technical_response.py", line 37, in null_technical_500_response
    six.reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.6/site-packages/six.py", line 692, in reraise
    raise value.with_traceback(tb)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 126, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 124, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.6/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/viewsets.py", line 116, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 495, in dispatch
    response = self.handle_exception(exc)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 455, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 492, in dispatch
    response = handler(request, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/mixins.py", line 20, in create
    serializer.is_valid(raise_exception=True)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/serializers.py", line 236, in is_valid
    self._validated_data = self.run_validation(self.initial_data)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/serializers.py", line 434, in run_validation
    value = self.to_internal_value(data)
  File "/app/api/serializers.py", line 40, in to_internal_value
    data = data.dict()
AttributeError: 'dict' object has no attribute 'dict'
```