### PR TITLE
Activate Celery beat on worker

### DIFF
--- a/docker/dokku/Procfile
+++ b/docker/dokku/Procfile
@@ -1,2 +1,2 @@
 web: gunicorn config.wsgi:application
-worker: /usr/local/bin/celery -A api worker --workdir .
+worker: /usr/local/bin/celery -A api worker -B --workdir .


### PR DESCRIPTION
Wie in #44 erwähnt.
Die worker müssen mit der `-B` Flag gestartet werden.