### PR TITLE
feat(JWT): rotate refresh token

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -101,6 +101,7 @@ SIMPLE_JWT = {
     "ALGORITHM": "HS256",
     "SIGNING_KEY": env.str("DJANGO_SECRET_KEY"),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=30),
+    "ROTATE_REFRESH_TOKENS": True,
 }
 
 REST_FRAMEWORK = {


### PR DESCRIPTION
Aktuell erhält das Frontend nach dem Login einen `refresh_token` (`RT`) und einen `access_token` (`AT`). `RT` hat nun eine Gültigkeitsdauer von 30 Tagen, während `AT` nur 5 Minuten gültig ist.

`AT` wird mit jedem Request an den Server geschickt und wenn noch nicht abgelaufen, kommen die angefragten Daten zurück. Wenn `AT` schon abgelaufen ist, erhält das Frontend den Status Code 401 und fragt automatisch mit Hilfe des `RT` nach einem neuen `AT`, der erneut 5 Minuten gültig ist.

Nun gibt es hier das Problem, dass das Frontend ab und an Batch-Requests an das Backend stellen muss. Als Beispiel, wenn man eine eingestochene Schicht beendet, wird zuerst ein `DELETE` an das Backend geschickt, um die `ClockedInShift` Instanz zu löschen. Danach wird mindestens ein, aber eventuell auch mehrere, `POST` Requests verschickt, um neue `Shift` Instanzen zu erstellen, welche die soeben ausgestochene Schicht persistieren.
Zwischen dem `DELETE` und einem der `POST` Requests kann nun der `AT` auslaufen. Das Frontend schickt eine Anfrage an das Backend um einen neuen `AT` zu erhalten. Wenn der User Glück hat, dann ist gerade `RT` ebenfalls abgelaufen. In diesem Fall loggt das Frontend den User aus.
Und nun ist per `DELETE` die `ClockedInShift` Instanz gelöscht worden, während noch keine, oder nicht alle `Shift`-Instanzen per `POST` erstellt worden sind.

Um das Problem zu lösen gibt es mehrere Möglichkeiten. Vor bestimmten Requests einen neuen `AT` Anfragen, Request-Warteschlangen die abgearbeitet werden, oder die hier im Backend gesetzte Lösung: bei jedem refresh des `AT` wird auch ein neuer `RT` mitgesendet. Das ist eine gängige Methode (vgl. z.B. https://www.oauth.com/oauth2-servers/making-authenticated-requests/refreshing-an-access-token/) und führt zu folgendem Verhalten:

1) Nutzt ein User die App mindestens einmal alle 30 Tage (aktuelle `RT` Laufzeit), so bleibt dieser für immer eingeloggt. So funktioniert es (wahrscheinlich?) z.B. hier auf GitHub und bei GMail.
2) Nutzt der User die App 31 Tage nicht und kommt wieder, so wird dieser ausgeloggt und muss sein Passwort neu eingeben.

Das Problem taucht mehrfach im Frontend auf und das ist die sauberste Lösung um es ein für alle mal zu lösen.