### PR TITLE
Management comands

### DIFF
--- a/api/management/commands/conftest.py
+++ b/api/management/commands/conftest.py
@@ -1,0 +1,1 @@
+from api.tests.conftest import *

--- a/api/management/commands/create_reports.py
+++ b/api/management/commands/create_reports.py
@@ -1,0 +1,49 @@
+from django.core.management.base import BaseCommand, CommandError
+from api.models import User, Contract, Report
+import datetime
+from dateutil.relativedelta import relativedelta
+
+
+class Command(BaseCommand):
+    help = "Create missing Reports for all Users for the given month and year."
+
+    def add_arguments(self, parser):
+        parser.add_argument("month", type=int)
+
+        parser.add_argument("year", type=int)
+
+    def handle(self, *args, **options):
+        report_cnt = 0
+        date = datetime.date(options["year"], options["month"], 1)
+
+        if date >= datetime.date.today():
+            raise CommandError("It's not allowed to create Reports for future months.")
+
+        for user in User.objects.filter(is_active=True, is_staff=False):
+
+            for contract in user.contracts.filter(
+                start_date__lt=date, end_date__gt=date
+            ).exclude(reports__month_year=date):
+                last_report = Report.objects.get(
+                    contract=contract, month_year=date - relativedelta(months=1)
+                )
+                carry_over_hours = datetime.timedelta(0)
+
+                if last_report:
+                    carry_over_hours = last_report.hours - datetime.timedelta(
+                        hours=contract.hours
+                    )
+
+                Report.objects.create(
+                    month_year=date,
+                    hours=carry_over_hours,
+                    contract=contract,
+                    user=user,
+                    created_by=user,
+                    modified_by=user,
+                )
+                report_cnt += 1
+
+        self.stdout.write(
+            self.style.SUCCESS("{} Reports were created.".format(report_cnt))
+        )

--- a/api/management/commands/test_commands.py
+++ b/api/management/commands/test_commands.py
@@ -1,0 +1,49 @@
+from io import StringIO
+from django.core.management import call_command
+from django.core.management.base import CommandError
+import pytest
+
+
+class TestCreateReportsCommand:
+    @pytest.mark.django_db
+    @pytest.mark.freeze_time("2019-01-02")
+    def test_no_report_created_if_report_exists(self, contract_object):
+        """
+        Test if the command skips the creation of a Report in the specified month if one already exists.
+        It's tested here with a Contract that only last for one month and hence got the Report created on
+        Contract creation.
+
+        :param contract_object:
+        :return:
+        """
+        out = StringIO()
+        call_command("create_reports", "1", "2019", stdout=out)
+
+        assert "0 Reports were created." in out.getvalue()
+
+    @pytest.mark.django_db
+    @pytest.mark.freeze_time("2019-01-02")
+    def test_created_report_successful(self, contract_ending_in_february, freezer):
+        """
+        Test that the command actually creates a Report.
+        :param contract_ending_in_february:
+        :param freezer:
+        :return:
+        """
+        freezer.move_to("2019-02-02")
+        out = StringIO()
+        call_command("create_reports", "2", "2019", stdout=out)
+
+        assert "1 Reports were created." in out.getvalue()
+
+    @pytest.mark.django_db
+    @pytest.mark.freeze_time("2019-01-02")
+    def test_created_report_fails_for_future_dates(self, contract_object):
+        """
+        Test that the command does not allow creation of reports in the future.
+        :param contract_object:
+        :return:
+        """
+        out = StringIO()
+        with pytest.raises(CommandError) as e_info:
+            call_command("create_reports", "2", "2019", stdout=out)

--- a/api/management/commands/update_reports.py
+++ b/api/management/commands/update_reports.py
@@ -1,0 +1,40 @@
+from django.core.management.base import BaseCommand, CommandError
+from api.models import Contract
+from api.utilities import update_reports
+import datetime
+
+
+class Command(BaseCommand):
+    help = "Updates the Reports of all Contracts from all active, non-staff Users."
+
+    def add_arguments(self, parser):
+        parser.add_argument("start_month", type=int)
+
+        parser.add_argument("start_year", type=int)
+        parser.add_argument(
+            "--all",
+            action="store_true",
+            help="Update thre Reports from all Users including non-active ones.",
+        )
+        # TODO: optional arguments --end_month, --end_year
+
+    def handle(self, *args, **options):
+        start_month_year = datetime.date(
+            options["start_year"], options["start_month"], 1
+        )
+        contract_qs = Contract.objects.filter(
+            user__is_active=True, user__is_staff=False, start_date__gte=start_month_year
+        )
+        contract_cnt = 0
+        for contract in contract_qs:
+            start_month_year = contract.start_date.replace(day=1)
+            update_reports(contract, start_month_year)
+            contract_cnt += 1
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "The Reports of {} Contracts were successfully updated.".format(
+                    contract_cnt
+                )
+            )
+        )


### PR DESCRIPTION
- [x] Erstellen eines Management Commands der es uns erlaubt fehlende Reports, bspw. bei Bugs und Inkonsistenzen, automatisch zu erstellen

- [x] Erstellen eines Management Commands der es uns erlaugt die Reports bestimmter Contracts zu updaten ohne Shift Objekte zu speichern.
    - [x] Refactor des `update_report_after_shift_save` signals um die eigentlich Updatefunktionalität mit einer allgemeinerer Funktionssignatur zu entkoppel. 
