### PR TITLE
Improve feedback app

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -91,6 +91,12 @@ DATABASES = {
 }
 DATABASES["default"]["ATOMIC_REQUESTS"] = True
 
+# EMAIL
+SYSTEM_EMAILS = {
+    "RECEIVER": env.str("SYSTEM_EMAIL_RECEIVER", "hello@example.com"),
+    "SENDER": env.str("SYSTEM_EMAIL_SENDER", "noreply@example.com"),
+}
+
 # Password validation
 # https://docs.djangoproject.com/en/dev/ref/settings/#auth-password-validators
 

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -38,7 +38,6 @@ INSTALLED_APPS = [
     "drf_yasg",
     "djoser",
     "corsheaders",
-    "anymail",
     "dj_rest_auth",
     "dj_rest_auth.registration",
     "django.contrib.sites",
@@ -144,16 +143,6 @@ CORS_ORIGIN_WHITELIST = env.tuple("CORS_ORIGIN_WHITELIST", default=())
 # The client must provide a `redirect_uri` query parameter when requesting the
 # authorization code URL. We retrieve it from the environment.
 GOETHE_OAUTH2_REDIRECT_URI = env.str("GOETHE_OAUTH2_REDIRECT_URI", default="")
-
-EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
-
-ANYMAIL = {
-    "MAILJET_API_KEY": env.str("MAILJET_API_KEY", default=""),
-    "MAILJET_SECRET_KEY": env.str("MAILJET_SECRET_KEY", default=""),
-}
-
-# hardcoded as recommended by docs
-MAILJET_API_URL = "https://api.mailjet.com/v3"
 
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -22,6 +22,7 @@ EMAIL_PORT = 1025
 EMAIL_BACKEND = env(
     "DJANGO_EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
 )
+SYSTEM_EMAIL = env.str("SYSTEM_EMAIL", "no-reply@example.com")
 
 MIDDLEWARE = ["request_logging.middleware.LoggingMiddleware"] + MIDDLEWARE
 

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -38,13 +38,18 @@ ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS")
 INSTALLED_APPS += ("raven.contrib.django.raven_compat",)
 
 # APPS
-INSTALLED_APPS += ("gunicorn",)
+INSTALLED_APPS += ("gunicorn", "anymail")
 
 # DATABASE
 DATABASES = {"default": env.db("DATABASE_URL")}
 DATABASES["default"]["ATOMIC_REQUESTS"] = True
 
 # EMAIL
+ANYMAIL = {
+    "MAILJET_API_KEY": env.str("MAILJET_API_KEY"),
+    "MAILJET_SECRET_KEY": env.str("MAILJET_SECRET_KEY"),
+}
+EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
 SYSTEM_EMAIL = env.str("SYSTEM_EMAIL")
 
 # Sentry Configuration

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -44,6 +44,9 @@ INSTALLED_APPS += ("gunicorn",)
 DATABASES = {"default": env.db("DATABASE_URL")}
 DATABASES["default"]["ATOMIC_REQUESTS"] = True
 
+# EMAIL
+SYSTEM_EMAIL = env.str("SYSTEM_EMAIL")
+
 # Sentry Configuration
 SENTRY_DSN = env("DJANGO_SENTRY_DSN")
 SENTRY_CLIENT = env(

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -50,7 +50,6 @@ ANYMAIL = {
     "MAILJET_SECRET_KEY": env.str("MAILJET_SECRET_KEY"),
 }
 EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
-SYSTEM_EMAIL = env.str("SYSTEM_EMAIL")
 
 # Sentry Configuration
 SENTRY_DSN = env("DJANGO_SENTRY_DSN")

--- a/feedback/serializers.py
+++ b/feedback/serializers.py
@@ -2,8 +2,7 @@ from rest_framework import serializers
 
 
 class FeedBackSerializer(serializers.Serializer):
-
-    user_name = serializers.CharField()
-    user_email = serializers.EmailField()
-    email_title = serializers.CharField()
-    email_content = serializers.CharField()
+    name = serializers.CharField()
+    email = serializers.EmailField()
+    title = serializers.CharField()
+    message = serializers.CharField()

--- a/feedback/tests/test_serializers.py
+++ b/feedback/tests/test_serializers.py
@@ -2,54 +2,54 @@ from rest_framework import serializers
 
 
 class TestFeedbackSerializer:
-    def test_serializer_has_user_name(self, feedback_serializer_field_dict):
+    def test_serializer_has_name(self, feedback_serializer_field_dict):
         """
-        Test Serializer has a user_name field.
+        Test serializer has a name field.
         :param feedback_serializer_field_dict:
         :return:
         """
-        assert feedback_serializer_field_dict.get("user_name")
+        assert feedback_serializer_field_dict.get("name")
 
-    def test_serializer_has_user_email(self, feedback_serializer_field_dict):
+    def test_serializer_has_email(self, feedback_serializer_field_dict):
         """
-        Test Serializer has a user_mail field.
+        Test serializer has a mail field.
         :param feedback_serializer_field_dict:
         :return:
         """
-        assert feedback_serializer_field_dict.get("user_email")
+        assert feedback_serializer_field_dict.get("email")
 
-    def test_serializer_has_email_title(self, feedback_serializer_field_dict):
+    def test_serializer_has_title(self, feedback_serializer_field_dict):
         """
-        Test Serializer has a email_title field.
+        Test serializer has a title field.
         :param feedback_serializer_field_dict:
         :return:
         """
-        assert feedback_serializer_field_dict.get("email_title")
+        assert feedback_serializer_field_dict.get("title")
 
-    def test_serializer_has_email_content(self, feedback_serializer_field_dict):
+    def test_serializer_has_message(self, feedback_serializer_field_dict):
         """
-        Test Serializer has a email_content field.
+        Test serializer has a message field.
         :param feedback_serializer_field_dict:
         :return:
         """
-        assert feedback_serializer_field_dict.get("email_content")
+        assert feedback_serializer_field_dict.get("message")
 
-    def test_field_type_user_name(self, feedback_serializer_field_dict):
+    def test_field_type_name(self, feedback_serializer_field_dict):
         assert isinstance(
-            feedback_serializer_field_dict.get("user_name"), serializers.CharField
+            feedback_serializer_field_dict.get("name"), serializers.CharField
         )
 
-    def test_field_type_user_email(self, feedback_serializer_field_dict):
+    def test_field_type_email(self, feedback_serializer_field_dict):
         assert isinstance(
-            feedback_serializer_field_dict.get("user_email"), serializers.EmailField
+            feedback_serializer_field_dict.get("email"), serializers.EmailField
         )
 
-    def test_field_type_email_title(self, feedback_serializer_field_dict):
+    def test_field_type_title(self, feedback_serializer_field_dict):
         assert isinstance(
-            feedback_serializer_field_dict.get("email_title"), serializers.CharField
+            feedback_serializer_field_dict.get("title"), serializers.CharField
         )
 
-    def test_field_type_email_content(self, feedback_serializer_field_dict):
+    def test_field_type_message(self, feedback_serializer_field_dict):
         assert isinstance(
-            feedback_serializer_field_dict.get("email_content"), serializers.CharField
+            feedback_serializer_field_dict.get("message"), serializers.CharField
         )

--- a/feedback/tests/test_utils.py
+++ b/feedback/tests/test_utils.py
@@ -1,0 +1,16 @@
+from ..utils import format_message
+
+
+def test_format_message():
+    output = format_message(
+        "http://example.com/feedback",
+        "Max Mustermann",
+        "max@example.com",
+        "Das ist eine Nachricht.",
+    )
+
+    expected_one_line = "Name: Max MustermannE-Mail: max@example.comNachricht:Das ist eine Nachricht.---------Das ist eine automatisch generierte Nachricht von Clock (System URL: http://example.com/feedback)"
+
+    output_one_line = "".join([line.replace("\n", "") for line in output.rstrip()])
+
+    assert output_one_line == expected_one_line

--- a/feedback/utils.py
+++ b/feedback/utils.py
@@ -1,0 +1,14 @@
+def format_message(url, name, email, message):
+    text = (
+        f"Name: {name}",
+        f"E-Mail: {email}",
+        "Nachricht:",
+        "",
+        message,
+        "",
+        "---------",
+        "",
+        f"Das ist eine automatisch generierte Nachricht von Clock (System URL: {url})",
+    )
+
+    return "\n".join(text)

--- a/feedback/views.py
+++ b/feedback/views.py
@@ -5,6 +5,7 @@ from django.core.mail import send_mail
 from rest_framework import status
 from drf_yasg.utils import swagger_auto_schema
 from config.settings.common import env
+from django.conf import settings
 
 
 class FeedBackView(generics.GenericAPIView):
@@ -26,6 +27,7 @@ class FeedBackView(generics.GenericAPIView):
                 name=data["name"], email=data["email"]
             ),
             message=data["message"],
+            recipient_list=[settings.SYSTEM_EMAIL],
             fail_silently=False,
         )
         if not message:

--- a/feedback/views.py
+++ b/feedback/views.py
@@ -21,10 +21,11 @@ class FeedBackView(generics.GenericAPIView):
         data = serializer.data
 
         message = send_mail(
-            subject=data["email_title"],
-            from_email="{0} <{1}>".format(serializer["user_name"], data["user_email"]),
-            message=data["email_content"],
-            recipient_list=[env.str("SYSTEM_EMAIL")],
+            subject=data["title"],
+            from_email="{name} <{email}>".format(
+                name=data["name"], email=data["email"]
+            ),
+            message=data["message"],
             fail_silently=False,
         )
         if not message:

--- a/feedback/views.py
+++ b/feedback/views.py
@@ -12,7 +12,9 @@ class FeedBackView(generics.GenericAPIView):
 
     permission_classes = ()
 
-    @swagger_auto_schema(responses={200: "The Views response is 200 if mail is sent"})
+    @swagger_auto_schema(
+        responses={200: "The view responds with 200 after sending the email."}
+    )
     def post(self, request, *args, **kwargs):
         serializer = FeedBackSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/feedback/views.py
+++ b/feedback/views.py
@@ -27,4 +27,4 @@ class FeedBackView(generics.GenericAPIView):
         )
         if not message:
             return Response(status=status.HTTP_400_BAD_REQUEST)
-        return Response(data=serializer)
+        return Response(data=serializer.data)

--- a/feedback/views.py
+++ b/feedback/views.py
@@ -5,22 +5,7 @@ from django.core.mail import EmailMessage
 from rest_framework import status
 from drf_yasg.utils import swagger_auto_schema
 from django.conf import settings
-
-
-def format_message(url, name, email, message):
-    text = (
-        f"Name: {name}",
-        f"E-Mail: {email}",
-        "Nachricht:",
-        "",
-        message,
-        "",
-        "---------",
-        "",
-        f"Das ist eine automatisch generierte Nachricht von Clock (System URL: {url})",
-    )
-
-    return "\n".join(text)
+from .utils import format_message
 
 
 class FeedBackView(generics.GenericAPIView):


### PR DESCRIPTION
- Fix an error in the view
- Update serializer field names
- Move environment variable into settings
- Install `mailjet` app only in production.
  - Move all settings associated with Mailjet to `production.py`.
  - Remove `MAILJET_API_KEY` and `MAILJET_SECRET_KEY` defaults to make them mandatory.