### PR TITLE
feat: delete user account

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -61,6 +61,10 @@ class UserSerializer(RestrictModificationModelSerializer):
         fields = "__all__"
 
 
+class DjoserUserSerializer(serializers.Serializer):
+    pass
+
+
 class ContractSerializer(RestrictModificationModelSerializer):
     class Meta:
         model = Contract

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 from freezegun import freeze_time
 from rest_framework import status, serializers
 
-from api.models import Contract, Shift, Report
+from api.models import Contract, Shift, Report, User
 
 
 class TestContractApiEndpoint:
@@ -760,3 +760,20 @@ class TestReportApiEndpoint:
             prepared_ReportViewSet_view.check_for_not_locked_shifts(
                 second_months_report_locked_shifts
             )
+
+
+class TestDjoserCustomizing:
+    @pytest.mark.django_db
+    def test_delete_user_custom_serializer(self, user_object, user_object_jwt, client):
+        """
+        Test if the user-delete view works with the specified custom UserSerializer.
+        :param user_object:
+        :param user_object_jwt:
+        :param client:
+        :return:
+        """
+        client.credentials(HTTP_AUTHORIZATION="Bearer {}".format(user_object_jwt))
+        response = client.delete(path=reverse("user-me"))
+        print(response.content)
+        assert response.status_code == 204
+        assert not User.objects.filter(id=user_object.id).exists()

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -128,7 +128,11 @@ REST_FRAMEWORK = {
 }
 
 
-DJOSER = {"TOKEN_MODEL": None}
+# Djoser
+DJOSER = {
+    "TOKEN_MODEL": None,
+    "SERIALIZERS": {"user_delete": "api.serializers.DjoserUserSerializer"},
+}
 
 # django-allauth: Query for the users email,
 # but do not prompt for verification


### PR DESCRIPTION
- Change default `user_delete` Djoser serializer to own dummy one. The frontend polls the user for confirmation.