### PR TITLE
fix(stundenzettel): show net work time in month

### DIFF
--- a/api/templates/api/stundenzettel.html
+++ b/api/templates/api/stundenzettel.html
@@ -59,7 +59,7 @@
           <div class="flex flex-wrap mb-4">
             <span class="w-full font-bold text-blue-600">Geleistete Arbeitszeit</span>
             <br />
-            <span class="text-gray-700">{{ general.total_worked_time }}</span>
+            <span class="text-gray-700">{{ general.net_worktime }}</span>
           </div>
           <div class="flex flex-wrap mb-4">
             <span class="w-full font-bold text-blue-600">Übertrag Folgemonat</span>
@@ -127,7 +127,7 @@
         <footer class="mt-8 text-xs text-gray-600">
           <div>Dieser Stundenzettel wurde maschinell mit Hilfe von <a class="text-blue-600" href="https://clockgu.netlify.com">Clock</a> erstellt.
           </div>
-          <div>Stand: 08. Juni 2020</div>
+          <div>Stand: 08. Juli 2020</div>
         </footer>
       </div>
     </div>

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -1,11 +1,9 @@
-# View tests come here
-
 import json
-import time
 from datetime import datetime
 
 import pytest
 from dateutil.parser import parse
+from dateutil.relativedelta import relativedelta
 from django.urls import reverse
 from freezegun import freeze_time
 from rest_framework import serializers, status
@@ -16,15 +14,21 @@ from api.models import Contract, Report, Shift, User
 class TestContractApiEndpoint:
     """
     This TestCase includes:
-       - tests which try accesing an Endpoint without a provided JWT
-           --> These tests will not be repeated for other Endpoints since in V1 every endpoint shares the same
-               permission_class and authentication_class
-       - tests which try to change the values for user, created_by and modified by
-           --> These tests will not be repeated for other Endpoints since in V1 every endpoint shares the same base
-               serializer which provides this provides this Functionality
-       - tests which try to create a Contract for a different user than who is issueing the request
-           --> These tests will not be repeated for other Endpoints since in V1 every endpoint shares the same base
-               serializer which provides this provides this Functionality
+    - tests which try accesing an Endpoint without a provided JWT
+        --> These tests will not be repeated for other Endpoints since in V1
+            every endpoint shares the same permission_class and
+            authentication_class
+
+    - tests which try to change the values for user, created_by and modified by
+        --> These tests will not be repeated for other Endpoints since in V1
+            every endpoint shares the same base serializer which provides this
+            provides this Functionality
+
+    - tests which try to create a Contract for a different user than who is
+    issueing the request
+        --> These tests will not be repeated for other Endpoints since in V1
+            every endpoint shares the same base serializer which provides this
+            provides this Functionality
     """
 
     @pytest.mark.django_db
@@ -645,50 +649,52 @@ class TestReportApiEndpoint:
         self, prepared_ReportViewSet_view, report_object
     ):
         """
-        Test if the method returns '00:00' for the carry over minutes
-        of the previous month if no report exists there.
+        Test that the method returns a 0 second timedelta if no Report exists
+        for the previous month.
+
         :param prepared_ReportViewSet_view:
         :param report_object:
         :return:
         """
 
-        carry_over_worktime = prepared_ReportViewSet_view.calculate_carry_over_worktime(
+        carryover_worktime = prepared_ReportViewSet_view.calculate_carryover_worktime(
             report_object, next_month=False
         )
-        assert carry_over_worktime == "00:00"
+        assert carryover_worktime == relativedelta(seconds=0)
 
     @pytest.mark.django_db
-    def test_method_for_carry_over_worktime_previous_month(
+    def test_method_for_carryover_worktime_previous_month(
         self, prepared_ReportViewSet_view, report_object, previous_report_object
     ):
         """
-        Test if the Method calculates the minutes to carry over from
-        the previous moth correctly.
+        Test that the method returns the carryover from the previous month.
+
         :param prepared_reportViewSet_view:
         :param report_object:
         :param previous_report_object:
         :return:
         """
-        carry_over_worktime = prepared_ReportViewSet_view.calculate_carry_over_worktime(
+        carryover_worktime = prepared_ReportViewSet_view.calculate_carryover_worktime(
             report_object, next_month=False
         )
-        assert carry_over_worktime == "02:00"
+        assert carryover_worktime == relativedelta(minutes=120)
 
     @pytest.mark.django_db
-    def test_method_for_carry_over_worktime_next_month(
+    def test_method_for_carryover_worktime_next_month(
         self, prepared_ReportViewSet_view, report_object
     ):
         """
-        Test if method calculates the minutes to carry over to next month
-        correctly.
+        Test that the method returns the carryover into the next month.
+
+
         :param prepared_ReportViewSet_view:
         :param report_object:
         :return:
         """
-        carry_over_worktime = prepared_ReportViewSet_view.calculate_carry_over_worktime(
+        carry_over_worktime = prepared_ReportViewSet_view.calculate_carryover_worktime(
             report_object, next_month=True
         )
-        assert carry_over_worktime == "-20:00"
+        assert carry_over_worktime == relativedelta(minutes=-1200)
 
     @pytest.mark.django_db
     def test_compile_pdf_returns_pdf(self, prepared_ReportViewSet_view, report_object):

--- a/api/views.py
+++ b/api/views.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.db.models import DurationField, F, Sum
@@ -311,9 +313,8 @@ class ReportViewSet(viewsets.ReadOnlyModelViewSet):
             }
         return content
 
-    def calculate_carry_over_worktime(self, report_object, next_month=True):
-
-        # Calculate carry over from last month
+    def calculate_carryover_worktime(self, report_object, next_month=True):
+        # Calculate carryover from last month
         report_to_carry = report_object
         if not next_month:
             try:
@@ -322,17 +323,14 @@ class ReportViewSet(viewsets.ReadOnlyModelViewSet):
                     month_year=report_object.month_year - relativedelta(months=1),
                 )
             except Report.DoesNotExist:
-                # If no Report Object exists we are in the case of the first Report of a Contract
-                # Hence return 00:00
-                return "00:00"
-        time_delta = report_to_carry.worktime - datetime.timedelta(
+                # We are looking at the first report of a contract. Return a
+                # 0-second timedelta.
+                return relativedelta(seconds=0)
+
+        td = report_to_carry.worktime - datetime.timedelta(
             minutes=report_object.contract.minutes
         )
-        relative_time = relativedelta(seconds=time_delta.total_seconds())
-
-        # relativedelta will in this case maximally convert the seconds into days we use this
-        # to format a string
-        return relativedelta_to_string(relative_time)
+        return relativedelta(seconds=td.total_seconds())
 
     def check_for_overlapping_shifts(self, shift_queryset):
         """
@@ -387,7 +385,7 @@ class ReportViewSet(viewsets.ReadOnlyModelViewSet):
         content = {}
         user = report_object.user
 
-        # Data for Header
+        # User data
         content["user_name"] = "{lastname}, {firstname}".format(
             lastname=user.last_name, firstname=user.first_name
         )
@@ -397,19 +395,27 @@ class ReportViewSet(viewsets.ReadOnlyModelViewSet):
         content["year"] = report_object.month_year.year
         content["long_month_name"] = month_names[report_object.month_year.month]
 
-        # Data for Footer
+        # Working time account (AZK)
         content["debit_work_time"] = relativedelta_to_string(
             relativedelta(minutes=report_object.contract.minutes)
         )
-        content["total_worked_time"] = relativedelta_to_string(
-            relativedelta(seconds=report_object.worktime.total_seconds())
-        )
+        time_worked = relativedelta(seconds=report_object.worktime.total_seconds())
+        content["total_worked_time"] = relativedelta_to_string(time_worked)
 
-        content["last_month_carry_over"] = self.calculate_carry_over_worktime(
-            report_object, next_month=False
+        carryover = {
+            "previous_month": self.calculate_carryover_worktime(
+                report_object, next_month=False
+            ),
+            "next_month": self.calculate_carryover_worktime(report_object),
+        }
+        content["last_month_carry_over"] = relativedelta_to_string(
+            carryover["previous_month"]
         )
-        content["next_month_carry_over"] = self.calculate_carry_over_worktime(
-            report_object
+        content["next_month_carry_over"] = relativedelta_to_string(
+            carryover["next_month"]
+        )
+        content["net_worktime"] = relativedelta_to_string(
+            time_worked - carryover["previous_month"]
         )
 
         return content
@@ -422,14 +428,16 @@ class ReportViewSet(viewsets.ReadOnlyModelViewSet):
         """
         content = {}
         shift_queryset = self.get_shifts_to_export(report_object)
-        # Check for overlapping Shifts
+
+        # Check for overlapping shifts
         self.check_for_overlapping_shifts(shift_queryset)
         self.check_for_not_locked_shifts(report_object)
-        shifts_content = self.aggregate_shift_content(shift_queryset)
-        general_content = self.aggregate_general_content(report_object, shift_queryset)
-        # Get all Days, as Dates, on which the user worked
-        content["shift_content"] = shifts_content
-        content["general"] = general_content
+
+        # Get all dates the user has worked on
+        content["shift_content"] = self.aggregate_shift_content(shift_queryset)
+        content["general"] = self.aggregate_general_content(
+            report_object, shift_queryset
+        )
 
         return content
 


### PR DESCRIPTION
Im Stundenzettel soll die tatsächlich geleistete Arbeitszeit im Monat (Summe der Netto-Arbeitszeit) angezeigt werden (siehe Screenshot). Zuvor wurde die Differenz zwischen dem vorherigen Übertrag + der Netto-Arbeitszeit angezeigt.

![image](https://user-images.githubusercontent.com/1052860/86532129-b86ad580-bec7-11ea-8445-3750db8fcfe6.png)


## To-Do

- [x] Zeitstempel des PDF im Footer aktualisieren. 