### PR TITLE
Hotfix 1

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -195,7 +195,7 @@ class ContractSerializer(RestrictModificationModelSerializer):
         :param start_date:
         :return:
         """
-        if start_date.day not in (1, 15):
+        if start_date.day not in (1, 16):
             raise serializers.ValidationError(
                 _("A contract must start on the 1st or 15th of a month.")
             )
@@ -208,7 +208,7 @@ class ContractSerializer(RestrictModificationModelSerializer):
         :param end_date:
         :return:
         """
-        if end_date.day not in (14, monthrange(end_date.year, end_date.month)[1]):
+        if end_date.day not in (15, monthrange(end_date.year, end_date.month)[1]):
             raise serializers.ValidationError(
                 _("A contract must end on the 14th or last day of a month.")
             )

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -9,7 +9,7 @@ from rest_framework import exceptions, serializers
 from api.models import ClockedInShift, Contract, Report, Shift, User
 from api.utilities import (
     create_reports_for_contract,
-    timedelta_to_string,
+    relativedelta_to_string,
     update_reports,
 )
 
@@ -32,7 +32,9 @@ class TimedeltaSerializerMethodField(serializers.SerializerMethodField):
         return_value = super(TimedeltaSerializerMethodField, self).to_representation(
             value
         )
-        return timedelta_to_string(return_value)
+        return relativedelta_to_string(
+            relativedelta(seconds=return_value.total_seconds())
+        )
 
 
 class RestrictModificationModelSerializer(serializers.ModelSerializer):
@@ -471,7 +473,7 @@ class ReportSerializer(RestrictModificationModelSerializer):
             return self.calculate_carryover(last_mon_report_object)
 
         except Report.DoesNotExist:
-            return datetime.timedelta(0)
+            return datetime.timedelta(minutes=obj.contract.initial_carryover_minutes)
 
     # TODO: We are currently calculating the carry_over from the previous month twice.
     def get_net_worktime(self, obj):

--- a/api/tests/test_serializers.py
+++ b/api/tests/test_serializers.py
@@ -55,7 +55,7 @@ class TestContractSerializerValidation:
     ):
         """
         The  ContractSerializer is tested whether it raises a Validation
-        if the start_date day is not the 1. or 15. of a month.
+        if the start_date day is not the 1. or 16. of a month.
         :param start_date_day_incorrect_contract_querydict:
         :param plain_request_object:
         :return:
@@ -72,7 +72,7 @@ class TestContractSerializerValidation:
     ):
         """
         The  ContractSerializer is tested whether it raises a Validation
-        if the start_date day is not the 14. or last day of a month.
+        if the start_date day is not the 15. or last day of a month.
         :param end_date_day_incorrect_contract_querydict:
         :param plain_request_object:
         :return:

--- a/api/tests/test_serializers.py
+++ b/api/tests/test_serializers.py
@@ -49,6 +49,7 @@ class TestContractSerializerValidation:
                 context={"request": plain_request_object},
             ).is_valid(raise_exception=True)
 
+    # TODO: Add test which explicitly verifies that contract with 1. or 16. as start_date is allowed.
     @pytest.mark.django_db
     def test_start_date_day_validation(
         self, start_date_day_incorrect_contract_querydict, plain_request_object
@@ -66,6 +67,7 @@ class TestContractSerializerValidation:
                 context={"request": plain_request_object},
             ).is_valid(raise_exception=True)
 
+    # TODO: Add test which explicitly verifies that contract with 15. or end of month as end_date is allowed.
     @pytest.mark.django_db
     def test_end_date_day_validation(
         self, end_date_day_incorrect_contract_querydict, plain_request_object

--- a/api/views.py
+++ b/api/views.py
@@ -323,9 +323,11 @@ class ReportViewSet(viewsets.ReadOnlyModelViewSet):
                     month_year=report_object.month_year - relativedelta(months=1),
                 )
             except Report.DoesNotExist:
-                # We are looking at the first report of a contract. Return a
-                # 0-second timedelta.
-                return relativedelta(seconds=0)
+                # We are looking at the first report of a contract. Return the
+                # initial_carryover_minutes as relativedelta.
+                return relativedelta(
+                    minutes=report_object.contract.initial_carryover_minutes
+                )
 
         td = report_to_carry.worktime - datetime.timedelta(
             minutes=report_object.contract.minutes


### PR DESCRIPTION
- [ ] net_worktime representation in ReportSerializer anpassen für initial_carryover_minutes

- [ ]  Contract start_date validierung auf 1. oder 16 ändern

- [ ] Contract end_date validierung auf 15. oder Ende des Monats ändern.

- [ ]  Stundenzetel Arbeitszeit und Übertrag aus vorigem Moant anpassen für initial_carryover_minutes