### PR TITLE
Add URL parameter filtering to shift endpoint.

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -4,6 +4,12 @@ from api.models import Shift
 
 
 class ShiftFilterSet(django_filters.FilterSet):
+
+    contract = django_filters.UUIDFilter(field_name="contract", lookup_expr="exact")
+
+    year = django_filters.NumberFilter(field_name="started", lookup_expr="year")
+    month = django_filters.NumberFilter(field_name="started", lookup_expr="month")
+
     class Meta:
         model = Shift
-        fields = {"started": ["exact", "lte"], "was_reviewed": ["exact"]}
+        fields = ["started", "contract"]

--- a/api/tests/test_filters.py
+++ b/api/tests/test_filters.py
@@ -1,15 +1,32 @@
+import django_filters
+
 from api.filters import ShiftFilterSet
 
 
 class TestShiftFilterSet:
-    def test_was_reviewed_filter(self):
-        assert "was_reviewed" in ShiftFilterSet._meta.fields
+    def test_contract_filter(self):
+        assert "contract" in ShiftFilterSet.get_filters()
 
-    def test_was_reviewed_lookups(self):
-        assert ShiftFilterSet._meta.fields["was_reviewed"] == ["exact"]
+    def test_year_filter(self):
+        assert "year" in ShiftFilterSet.get_filters()
 
-    def test_started_filter(self):
-        assert "started" in ShiftFilterSet._meta.fields
+    def test_month_filter(self):
+        assert "month" in ShiftFilterSet.get_filters()
 
-    def test_started_lookups(self):
-        assert ShiftFilterSet._meta.fields["started"] == ["exact", "lte"]
+    def test_contract_lookups(self):
+        filter = ShiftFilterSet.get_filters().get("contract")
+        assert isinstance(filter, django_filters.UUIDFilter)
+        assert filter.field_name == "contract"
+        assert filter.lookup_expr == "exact"
+
+    def test_year_lookups(self):
+        filter = ShiftFilterSet.get_filters().get("year")
+        assert isinstance(filter, django_filters.NumberFilter)
+        assert filter.field_name == "started"
+        assert filter.lookup_expr == "year"
+
+    def test_month_lookups(self):
+        filter = ShiftFilterSet.get_filters().get("month")
+        assert isinstance(filter, django_filters.NumberFilter)
+        assert filter.field_name == "started"
+        assert filter.lookup_expr == "month"


### PR DESCRIPTION
- [x] Filter for contract

- [x] Filter for `started__year` as `year` in URL

- [x] Filter for `started__month` as `month` in URL