### PR TITLE
Berücksichtige Vertragsstart/ende Mitte des Monats

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,11 +1,11 @@
 import uuid
-from datetime import datetime, timedelta
-
+from calendar import monthrange
 from django.contrib.auth.base_user import BaseUserManager
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 from taggit.managers import TaggableManager
 from taggit.models import GenericUUIDTaggedItemBase, TaggedItemBase
+from datetime import timedelta
 
 
 class UUIDTaggedItem(GenericUUIDTaggedItemBase, TaggedItemBase):
@@ -194,6 +194,38 @@ class Report(models.Model):
     created_by = models.ForeignKey(to=User, related_name="+", on_delete=models.CASCADE)
     modified_at = models.DateTimeField(auto_now=True)
     modified_by = models.ForeignKey(to=User, related_name="+", on_delete=models.CASCADE)
+
+    @property
+    def debit_worktime(self):
+        """
+        Calculate the actual debit worktime for a report.
+
+        The actual debitworktime can be lower than the provided value from the contract due to:
+        incomplete months (contract starts not at first, or end not on the last of a month.)
+        """
+        month = self.month_year.month
+        year = self.month_year.year
+        end_day = monthrange(year, month)[1]
+
+        if (
+            self.contract.start_date.month == month
+            and self.contract.start_date.year == year
+        ):
+            minutes = (
+                (end_day - self.contract.start_date.day + 1)
+                / end_day
+                * self.contract.minutes
+            )
+            return timedelta(minutes=minutes)
+
+        if (
+            self.contract.end_date.month == month
+            and self.contract.end_date.year == year
+        ):
+            minutes = self.contract.end_date.day / end_day * self.contract.minutes
+            return timedelta(minutes=minutes)
+
+        return timedelta(minutes=self.contract.minutes)
 
     class Meta:
         ordering = ["month_year"]

--- a/api/models.py
+++ b/api/models.py
@@ -1,11 +1,12 @@
 import uuid
 from calendar import monthrange
+from datetime import timedelta
+
 from django.contrib.auth.base_user import BaseUserManager
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 from taggit.managers import TaggableManager
 from taggit.models import GenericUUIDTaggedItemBase, TaggedItemBase
-from datetime import timedelta
 
 
 class UUIDTaggedItem(GenericUUIDTaggedItemBase, TaggedItemBase):

--- a/api/models.py
+++ b/api/models.py
@@ -1,6 +1,6 @@
 import uuid
 from calendar import monthrange
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from django.contrib.auth.base_user import BaseUserManager
 from django.contrib.auth.models import AbstractUser

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -461,9 +461,7 @@ class ReportSerializer(RestrictModificationModelSerializer):
         }
 
     def calculate_carryover(self, report_object):
-        return report_object.worktime - datetime.timedelta(
-            minutes=report_object.contract.minutes
-        )
+        return report_object.worktime - report_object.debit_worktime
 
     def get_carry_over_last_month(self, obj):
         try:
@@ -471,10 +469,11 @@ class ReportSerializer(RestrictModificationModelSerializer):
                 contract=obj.contract,
                 month_year=obj.month_year - relativedelta(months=1),
             )
-            return self.calculate_carryover(last_mon_report_object)
 
         except Report.DoesNotExist:
             return datetime.timedelta(minutes=obj.contract.initial_carryover_minutes)
+
+        return self.calculate_carryover(last_mon_report_object)
 
     # TODO: We are currently calculating the carry_over from the previous month twice.
     def get_net_worktime(self, obj):

--- a/api/tests/conftest_files/contract_conftest.py
+++ b/api/tests/conftest_files/contract_conftest.py
@@ -5,6 +5,7 @@ from pytz import datetime
 from rest_framework.request import QueryDict
 
 from api.models import Contract
+from api.utilities import update_reports
 
 # This conftest file provides all necessary test data concerning the Contract Model.
 # It will be imported by the conftest.py in the parent directory.
@@ -524,3 +525,23 @@ def contract_locked_shifts(create_n_contract_objects, user_object):
     return create_n_contract_objects(
         (1,), start_date=_start_date, end_date=_end_date, user=user_object
     )[0]
+
+
+@pytest.fixture
+def contract_start_mid_january(create_n_contract_objects, user_object):
+    """
+    Provide contract which starts at the 16. of January and ends in february.
+    :param create_n_contract_objects:
+    :param user_object:
+    :return:
+    """
+    cont = create_n_contract_objects(
+        (1,),
+        start_date=datetime.date(2020, 1, 16),
+        end_date=datetime.date(2020, 2, 29),
+        user=user_object,
+        carryover_target_date=datetime.date(2020, 1, 1),
+    )[0]
+
+    update_reports(cont, datetime.date(2020, 2, 1))  # bring second Report up to date
+    return cont

--- a/api/tests/conftest_files/general_conftest.py
+++ b/api/tests/conftest_files/general_conftest.py
@@ -85,6 +85,21 @@ def prepared_ContractViewSet_view(user_object):
     request.user = user_object
     return setup_view(ContractViewSet(), request)
 
+@pytest.fixture
+def prepared_ReportViewSet_view_mid_january(contract_start_mid_january):
+    """
+    Prepare
+    :param report_object:
+    :return:
+    """
+    report_object = contract_start_mid_january.reports.get(
+        month_year=contract_start_mid_january.start_date.replace(day=1)
+    )
+    factory = RequestFactory()
+    request = factory.get(
+        reverse("api:reports-export", args=["{}".format(report_object.id)])
+    )
+    return setup_view(ReportViewSet(), request)
 
 @pytest.fixture
 def positive_relativedelta_object():

--- a/api/tests/conftest_files/general_conftest.py
+++ b/api/tests/conftest_files/general_conftest.py
@@ -85,6 +85,7 @@ def prepared_ContractViewSet_view(user_object):
     request.user = user_object
     return setup_view(ContractViewSet(), request)
 
+
 @pytest.fixture
 def prepared_ReportViewSet_view_mid_january(contract_start_mid_january):
     """
@@ -100,6 +101,7 @@ def prepared_ReportViewSet_view_mid_january(contract_start_mid_january):
         reverse("api:reports-export", args=["{}".format(report_object.id)])
     )
     return setup_view(ReportViewSet(), request)
+
 
 @pytest.fixture
 def positive_relativedelta_object():

--- a/api/tests/test_serializers.py
+++ b/api/tests/test_serializers.py
@@ -1,16 +1,16 @@
 import datetime
 
 import pytest
+from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 from rest_framework import exceptions, serializers
-from dateutil.relativedelta import relativedelta
 
 from api.models import Report
 from api.serializers import (
     ClockedInShiftSerializer,
     ContractSerializer,
-    ShiftSerializer,
     ReportSerializer,
+    ShiftSerializer,
 )
 
 

--- a/api/utilities.py
+++ b/api/utilities.py
@@ -108,13 +108,14 @@ def update_reports(contract, month_year):
     :return:
     """
 
-    debit_worktime = datetime.timedelta(minutes=contract.minutes)
     previous_report = Report.objects.filter(
         contract=contract, month_year=month_year - relativedelta(months=1)
     )
     carry_over_worktime = datetime.timedelta(minutes=contract.initial_carryover_minutes)
     if previous_report.exists():
-        carry_over_worktime = previous_report.first().worktime - debit_worktime
+        carry_over_worktime = (
+            previous_report.first().worktime - previous_report.first().debit_worktime
+        )
     # Loop over all Reports starting from month in which the created/update shift
     # took place.
     for report in Report.objects.filter(contract=contract, month_year__gte=month_year):
@@ -133,7 +134,7 @@ def update_reports(contract, month_year):
         ]
         report.worktime = carry_over_worktime + total_work_time
         report.save()
-        carry_over_worktime = report.worktime - debit_worktime
+        carry_over_worktime = report.worktime - report.debit_worktime
 
 
 def update_report_after_shift_save(sender, instance, created=False, **kwargs):

--- a/api/views.py
+++ b/api/views.py
@@ -331,9 +331,8 @@ class ReportViewSet(viewsets.ReadOnlyModelViewSet):
                     minutes=report_object.contract.initial_carryover_minutes
                 )
 
-        td = report_to_carry.worktime - datetime.timedelta(
-            minutes=report_object.contract.minutes
-        )
+        td = report_to_carry.worktime - report_to_carry.debit_worktime
+
         return relativedelta(seconds=td.total_seconds())
 
     def check_for_overlapping_shifts(self, shift_queryset):
@@ -400,9 +399,7 @@ class ReportViewSet(viewsets.ReadOnlyModelViewSet):
         content["long_month_name"] = month_names[report_object.month_year.month]
 
         # Working time account (AZK)
-        content["debit_work_time"] = relativedelta_to_string(
-            relativedelta(minutes=report_object.contract.minutes)
-        )
+        content["debit_work_time"] = timedelta_to_string(report_object.debit_worktime)
         time_worked = relativedelta(seconds=report_object.worktime.total_seconds())
         content["total_worked_time"] = relativedelta_to_string(time_worked)
 


### PR DESCRIPTION
Für Verträge, die in der Mitte des Monats beginnend/enden beträgt die Sollarbeitszeit:

1. Start Mitte des Monats --> (Monatsende - Start +1 ) / Tage im Monat * Sollarbeitszeit
2. Ende Mitte des Monats ---> End-tag/ Tage im Monat * Sollarbeitszeit

Dazu müssen folgende Änderungen gemacht werden

- [x] Implementierung eines `@property`  `debit_worktime` im `Report` model
- [x] Anpassung des `ReportSerializers`
- [x] Anpassung der `update_reports` Funktion (utilities.py)
- [x] Anpassung des Stundenzettelexports