### PR TITLE
Hotfix - Stundenzettel Relativedelta

### DIFF
--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime
 
 import pytest
+from datetime import timedelta
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 from django.urls import reverse
@@ -696,7 +697,7 @@ class TestReportApiEndpoint:
         carryover_worktime = prepared_ReportViewSet_view.calculate_carryover_worktime(
             report_object, next_month=False
         )
-        assert carryover_worktime == relativedelta(seconds=0)
+        assert carryover_worktime == timedelta(0)
 
     @pytest.mark.django_db
     def test_method_for_carryover_worktime_previous_month(
@@ -713,7 +714,8 @@ class TestReportApiEndpoint:
         carryover_worktime = prepared_ReportViewSet_view.calculate_carryover_worktime(
             report_object, next_month=False
         )
-        assert carryover_worktime == relativedelta(minutes=120)
+
+        assert carryover_worktime == timedelta(minutes=120)
 
     @pytest.mark.django_db
     def test_method_for_carryover_worktime_next_month(
@@ -730,7 +732,7 @@ class TestReportApiEndpoint:
         carry_over_worktime = prepared_ReportViewSet_view.calculate_carryover_worktime(
             report_object, next_month=True
         )
-        assert carry_over_worktime == relativedelta(minutes=-1200)
+        assert carry_over_worktime == timedelta(minutes=-1200)
 
     @pytest.mark.django_db
     def test_method_for_carryover_worktime_next_month_for_midmonth_start(
@@ -751,10 +753,7 @@ class TestReportApiEndpoint:
             rep, next_month=True
         )
 
-        assert (
-            carry_over_worktime.normalized()
-            == relativedelta(minutes=-16 / 31 * 1200).normalized()
-        )
+        assert carry_over_worktime == timedelta(minutes=-16 / 31 * 1200)
 
     @pytest.mark.django_db
     def test_method_for_carryover_worktime_last_month_for_midmonth_start(
@@ -775,10 +774,7 @@ class TestReportApiEndpoint:
             rep, next_month=False
         )
 
-        assert (
-            carry_over_worktime.normalized()
-            == relativedelta(minutes=-16 / 31 * 1200).normalized()
-        )
+        assert carry_over_worktime == timedelta(minutes=-16 / 31 * 1200)
 
     @pytest.mark.django_db
     def test_compile_pdf_returns_pdf(self, prepared_ReportViewSet_view, report_object):

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -1,8 +1,7 @@
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
-from datetime import timedelta
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 from django.urls import reverse

--- a/api/utilities.py
+++ b/api/utilities.py
@@ -22,9 +22,17 @@ def relativedelta_to_string(relative_time_delta):
     :param relative_time_delta:
     :return:
     """
+    time_data = (
+        relative_time_delta.days,
+        relative_time_delta.hours,
+        relative_time_delta.minutes,
+    )
+    format_string = "{hours:02g}:{minutes:02g}"
+    if any(map(lambda x: x < 0, time_data)):
+        format_string = "-{hours:02g}:{minutes:02g}"
 
-    return "{hours:02g}:{minutes:02g}".format(
-        hours=relative_time_delta.days * 24 + relative_time_delta.hours,
+    return format_string.format(
+        hours=abs(relative_time_delta.days * 24 + relative_time_delta.hours),
         minutes=abs(relative_time_delta.minutes),
     )
 

--- a/api/views.py
+++ b/api/views.py
@@ -332,8 +332,7 @@ class ReportViewSet(viewsets.ReadOnlyModelViewSet):
                 )
 
         td = report_to_carry.worktime - report_to_carry.debit_worktime
-
-        return relativedelta(seconds=td.total_seconds())
+        return td
 
     def check_for_overlapping_shifts(self, shift_queryset):
         """
@@ -400,8 +399,10 @@ class ReportViewSet(viewsets.ReadOnlyModelViewSet):
 
         # Working time account (AZK)
         content["debit_work_time"] = timedelta_to_string(report_object.debit_worktime)
-        time_worked = relativedelta(seconds=report_object.worktime.total_seconds())
-        content["total_worked_time"] = relativedelta_to_string(time_worked)
+        time_worked_seconds = report_object.worktime.total_seconds()
+        content["total_worked_time"] = relativedelta_to_string(
+            relativedelta(seconds=time_worked_seconds)
+        )
 
         carryover = {
             "previous_month": self.calculate_carryover_worktime(
@@ -410,13 +411,16 @@ class ReportViewSet(viewsets.ReadOnlyModelViewSet):
             "next_month": self.calculate_carryover_worktime(report_object),
         }
         content["last_month_carry_over"] = relativedelta_to_string(
-            carryover["previous_month"]
+            relativedelta(seconds=carryover["previous_month"].total_seconds())
         )
         content["next_month_carry_over"] = relativedelta_to_string(
-            carryover["next_month"]
+            relativedelta(seconds=carryover["next_month"].total_seconds())
         )
         content["net_worktime"] = relativedelta_to_string(
-            time_worked - carryover["previous_month"]
+            relativedelta(
+                seconds=time_worked_seconds
+                - carryover["previous_month"].total_seconds()
+            )
         )
 
         return content

--- a/api/views.py
+++ b/api/views.py
@@ -327,7 +327,7 @@ class ReportViewSet(viewsets.ReadOnlyModelViewSet):
             except Report.DoesNotExist:
                 # We are looking at the first report of a contract. Return the
                 # initial_carryover_minutes as relativedelta.
-                return relativedelta(
+                return timedelta(
                     minutes=report_object.contract.initial_carryover_minutes
                 )
 

--- a/api/views.py
+++ b/api/views.py
@@ -326,11 +326,10 @@ class ReportViewSet(viewsets.ReadOnlyModelViewSet):
                 )
             except Report.DoesNotExist:
                 # We are looking at the first report of a contract. Return the
-                # initial_carryover_minutes as relativedelta.
+                # initial_carryover_minutes as timedelta.
                 return timedelta(
                     minutes=report_object.contract.initial_carryover_minutes
                 )
-
         td = report_to_carry.worktime - report_to_carry.debit_worktime
         return td
 


### PR DESCRIPTION
Die String umwandlung `relativedelta_to_string`  in `api/utilities.py` hat außer Acht gelassen, dass zum Beispiel auch `relativedelta(minutes=-55)` gibt. Diese wurden bis jetzt unter Vernachlässigung des "-" behandelt.
Des Weiteren ist das Verhalten von `relativedelta` unter "-" seltsam.
Bsp.: `relativedelta(hours=2, minutes=2) - relativedelta(mintues=7) == relativedelta(hours=2, minutes=-5)`

Der Code ging bis jetzt davon aus, dass das Resultat `relativedelta(hours=1, minutes=55)`.

Beides wird in diesem Hotfix behoben