### PR TITLE
Fix Report update

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -408,11 +408,24 @@ class ShiftSerializer(RestrictModificationModelSerializer):
         :param validated_data:
         :return:
         """
+
+        # To update the old report if we change the contract we need
+        # to check this
+        contract_changed = bool(validated_data.get("contract"))
+        if not self.partial:
+            contract_changed = validated_data.get("contract") != instance.contract
+        # keep track of possibly old contract
+        # and old started value
+        orig_contract = instance.contract
+        orig_started = instance.started
         tags = validated_data.pop("tags", None)
         updated_object = super(ShiftSerializer, self).update(instance, validated_data)
 
         if isinstance(tags, list):
             updated_object.tags.set(*tags)
+
+        if contract_changed:
+            update_reports(orig_contract, orig_started.date().replace(day=1))
 
         return updated_object
 

--- a/api/tests/conftest_files/general_conftest.py
+++ b/api/tests/conftest_files/general_conftest.py
@@ -111,3 +111,12 @@ def positive_relativedelta_object():
 @pytest.fixture
 def negative_relativedelta_object():
     return relativedelta(days=-6, hours=-4, minutes=-23, seconds=-15)
+
+
+@pytest.fixture
+def test_contract_change(
+    create_n_contract_objects, create_n_shift_objects, user_object
+):
+    contracts = create_n_contract_objects((1, 3), user_object)
+    create_n_shift_objects((1,), user=user_object, contract=contracts[0])
+    return contracts


### PR DESCRIPTION
Es kommt zu dem fall bei dem der Contract einer Schicht geändert wird. 
Dabei wir der Report des neuen contracts zwar ge-updated der alte aber nicht.
Das gilt es zu beheben.