### PR TITLE
disabling clocking on holidays, sundays and already sick or vacation …

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -327,11 +327,13 @@ class ShiftSerializer(RestrictModificationModelSerializer):
         contract = data.get("contract")
         shift_type = data.get("type")
         was_reviewed = data.get("was_reviewed", False)
-        vacation_sick_shifts_this_day = Shift.objects.filter(
+
+        this_day = Shift.objects.filter(
             contract=contract,
-            started__year=started.year,
-            started__month=started.month,
-            started__day=started.day,
+            started__date=started,
+        )
+
+        vacation_sick_shifts_this_day = this_day.filter(
             type__in=('sk', 'vn')
         )
 
@@ -341,11 +343,6 @@ class ShiftSerializer(RestrictModificationModelSerializer):
             contract = data.get("contract", self.instance.contract)
             was_reviewed = data.get("was_reviewed", self.instance.was_reviewed)
             vacation_sick_shifts_this_day = vacation_sick_shifts_this_day.exclude(id=self.instance.id)
-
-        this_day = Shift.objects.filter(
-            contract=contract,
-            started__date=started,
-        )
 
         if self.instance:
             uuid = self.instance.id
@@ -569,13 +566,11 @@ class ClockedInShiftSerializer(RestrictModificationModelSerializer):
         contract = data.get("contract")
         vacation_sick_shifts_this_day = Shift.objects.filter(
             contract=contract,
-            started__year=started.year,
-            started__month=started.month,
-            started__day=started.day,
+            started__date=started,
             type__in=('sk', 'vn')
         )
 
-        # validate that there is already one vacation or sick shift this day
+        # validate that there is not already one vacation or sick shift this day
         if vacation_sick_shifts_this_day.exists():
             raise serializers.ValidationError(
                 _("Live clocking is not allowed on days where already a vacation or a sick shift is clocked.")

--- a/api/tests/conftest_files/clockedinshift_conftest.py
+++ b/api/tests/conftest_files/clockedinshift_conftest.py
@@ -19,13 +19,14 @@ def valid_clockedinshift_json(user_object, contract_object):
     """
     user = str(user_object.id)
     data = {
-        "started": datetime.datetime(2019, 1, 29, 14, tzinfo=utc).isoformat(),
+        "started": datetime.datetime(2019, 4, 23, 14, tzinfo=utc).isoformat(),
         "contract": str(contract_object.id),
         "user": user,
         "created_by": user,
         "modified_by": user,
     }
     return data
+
 
 @pytest.fixture
 def valid_clockedinshift_sunday_json(user_object, contract_object):
@@ -46,6 +47,7 @@ def valid_clockedinshift_sunday_json(user_object, contract_object):
     }
     return data
 
+
 @pytest.fixture
 def valid_clockedinshift_holiday_json(user_object, contract_object):
     """
@@ -65,6 +67,7 @@ def valid_clockedinshift_holiday_json(user_object, contract_object):
     }
     return data
 
+
 @pytest.fixture
 def valid_clockedinshift_querydict(valid_clockedinshift_json):
     """
@@ -76,6 +79,7 @@ def valid_clockedinshift_querydict(valid_clockedinshift_json):
     qdict.update(valid_clockedinshift_json)
     return qdict
 
+
 @pytest.fixture
 def valid_clockedinshift_sunday_querydict(valid_clockedinshift_sunday_json):
     """
@@ -86,6 +90,7 @@ def valid_clockedinshift_sunday_querydict(valid_clockedinshift_sunday_json):
     qdict = QueryDict("", mutable=True)
     qdict.update(valid_clockedinshift_sunday_json)
     return qdict
+
 
 @pytest.fixture
 def valid_clockedinshift_holiday_querydict(valid_clockedinshift_holiday_json):

--- a/api/tests/conftest_files/clockedinshift_conftest.py
+++ b/api/tests/conftest_files/clockedinshift_conftest.py
@@ -27,6 +27,43 @@ def valid_clockedinshift_json(user_object, contract_object):
     }
     return data
 
+@pytest.fixture
+def valid_clockedinshift_sunday_json(user_object, contract_object):
+    """
+    This fixture provides a valid (according to ClockedInShiftSerializer) JSON dictionary for a clocked-in shift
+    which is created manually on a sunday.
+    :param user_object:
+    :param contract_object:
+    :return:
+    """
+    user = str(user_object.id)
+    data = {
+        "started": datetime.datetime(2019, 1, 6, 14, tzinfo=utc).isoformat(),
+        "contract": str(contract_object.id),
+        "user": user,
+        "created_by": user,
+        "modified_by": user,
+    }
+    return data
+
+@pytest.fixture
+def valid_clockedinshift_holiday_json(user_object, contract_object):
+    """
+    This fixture provides a valid (according to ClockedInShiftSerializer) JSON dictionary for a clocked-in shift
+    which is created manually on a holiday.
+    :param user_object:
+    :param contract_object:
+    :return:
+    """
+    user = str(user_object.id)
+    data = {
+        "started": datetime.datetime(2019, 1, 1, 14, tzinfo=utc).isoformat(),
+        "contract": str(contract_object.id),
+        "user": user,
+        "created_by": user,
+        "modified_by": user,
+    }
+    return data
 
 @pytest.fixture
 def valid_clockedinshift_querydict(valid_clockedinshift_json):
@@ -37,6 +74,28 @@ def valid_clockedinshift_querydict(valid_clockedinshift_json):
     """
     qdict = QueryDict("", mutable=True)
     qdict.update(valid_clockedinshift_json)
+    return qdict
+
+@pytest.fixture
+def valid_clockedinshift_sunday_querydict(valid_clockedinshift_sunday_json):
+    """
+    This fixture creates a QueryDict out of the valid_shift_json.
+    :param valid_clockedinshift_sunday_json:
+    :return: QueryDict
+    """
+    qdict = QueryDict("", mutable=True)
+    qdict.update(valid_clockedinshift_sunday_json)
+    return qdict
+
+@pytest.fixture
+def valid_clockedinshift_holiday_querydict(valid_clockedinshift_holiday_json):
+    """
+    This fixture creates a QueryDict out of the valid_shift_json.
+    :param valid_clockedinshift_holiday_json:
+    :return: QueryDict
+    """
+    qdict = QueryDict("", mutable=True)
+    qdict.update(valid_clockedinshift_holiday_json)
     return qdict
 
 

--- a/api/tests/conftest_files/shift_conftest.py
+++ b/api/tests/conftest_files/shift_conftest.py
@@ -543,6 +543,29 @@ def shift_content_aggregation_merges_shifts(
 
 
 @pytest.fixture
+def valid_vacation_shift(
+        user_object, contract_object, create_n_shift_objects
+):
+    """
+    This fixture creates a vacation shift at 23.04.2019.
+    :param user_object:
+    :param contract_object:
+    :param create_n_shift_objects:
+    :return:
+    """
+    create_n_shift_objects(
+        (1,),
+        user=user_object,
+        contract=contract_object,
+        started=datetime.datetime(2019, 4, 23, 14).astimezone(tz),
+        stopped=datetime.datetime(2019, 4, 23, 18).astimezone(tz),
+        type="vn",
+    )
+    return Shift.objects.filter(
+        user=user_object, contract=contract_object, started__month=4, started__day=2019).order_by("started")
+
+
+@pytest.fixture
 def two_shifts_with_one_vacation_shift(
     user_object, contract_object, create_n_shift_objects
 ):

--- a/api/tests/test_serializers.py
+++ b/api/tests/test_serializers.py
@@ -595,7 +595,6 @@ class TestClockedInShiftSerializer:
         The ClockedInShiftSerializer is tested if a valid JSON passes validation.
         :param valid_clockedinshift_querydict:
         :param plain_request_object:
-        :return:
         """
         ClockedInShiftSerializer(
             data=valid_clockedinshift_querydict,
@@ -611,11 +610,59 @@ class TestClockedInShiftSerializer:
         if the provided contract does not belong to the provided user.
         :param clockedinshift_invalid_contract_json:
         :param plain_request_object:
-        :return:
         """
         with pytest.raises(serializers.ValidationError):
             ShiftSerializer(
                 data=clockedinshift_invalid_contract_json,
+                context={"request": plain_request_object},
+            ).is_valid(raise_exception=True)
+
+    @pytest.mark.django_db
+    def test_invalid_clocking_on_day_with_vacation_shift(
+            self, valid_vacation_shift, valid_clockedinshift_querydict, plain_request_object
+    ):
+        """
+        The  ClockedInShiftSerializer is tested whether it raises a Validation
+        Error if there is already a vacation shift on this day.
+        :param valid_vacation_shift:
+        :param valid_clockedinshift_querydict:
+        :param plain_request_object:
+        """
+        with pytest.raises(serializers.ValidationError):
+            ClockedInShiftSerializer(
+                data=valid_clockedinshift_querydict,
+                context={"request": plain_request_object},
+            ).is_valid(raise_exception=True)
+
+    @pytest.mark.django_db
+    def test_invalid_clocking_on_sunday(
+        self, valid_clockedinshift_sunday_querydict, plain_request_object
+    ):
+        """
+        The  ClockedInShiftSerializer is tested whether it raises a Validation
+        Error if the clocked Shift is on a sunday.
+        :param valid_clockedinshift_sunday_querydict:
+        :param plain_request_object:
+        """
+        with pytest.raises(serializers.ValidationError):
+            ClockedInShiftSerializer(
+                data=valid_clockedinshift_sunday_querydict,
+                context={"request": plain_request_object},
+            ).is_valid(raise_exception=True)
+
+    @pytest.mark.django_db
+    def test_invalid_clocking_on_holiday(
+        self, valid_clockedinshift_holiday_querydict, plain_request_object
+    ):
+        """
+        The  ClockedInShiftSerializer is tested whether it raises a Validation
+        Error if the clocked Shift is on a holiday.
+        :param valid_clockedinshift_holiday_querydict:
+        :param plain_request_object:
+        """
+        with pytest.raises(serializers.ValidationError):
+            ClockedInShiftSerializer(
+                data=valid_clockedinshift_holiday_querydict,
                 context={"request": plain_request_object},
             ).is_valid(raise_exception=True)
 


### PR DESCRIPTION
…clocked days

- [x] nicht an Feiertagen
- [x] nicht an Sonntagen
- [x] nicht an Tagen mit bereits gebuchten Krank- bzw Urlaubs-Schichten


Ggf. ist zu überlegen die Dopplung aus der Validate der Shifts und der ClockedInShifts zur Bestimmung von allen KU-Schichten in eine Funktion auszugliedern.