### PR TITLE
Remove unnecessary net_worktime. It is no longer needed since we alre…

### DIFF
--- a/api/tests/conftest_files/report_conftest.py
+++ b/api/tests/conftest_files/report_conftest.py
@@ -210,6 +210,5 @@ def aggregated_report_data():
             "total_worked_time": "02:00",
             "last_month_carry_over": "00:00",
             "next_month_carry_over": "-18:00",
-            "net_worktime": "02:00",
         },
     }

--- a/api/views.py
+++ b/api/views.py
@@ -521,13 +521,6 @@ class ReportViewSet(viewsets.ReadOnlyModelViewSet):
         content["next_month_carry_over"] = relativedelta_to_string(
             relativedelta(seconds=carryover["next_month"].total_seconds())
         )
-        content["net_worktime"] = relativedelta_to_string(
-            relativedelta(
-                seconds=time_worked_seconds
-                - carryover["previous_month"].total_seconds()
-            )
-        )
-
         return content
 
     def aggregate_export_content(self, report_object):


### PR DESCRIPTION
…ady decoupled the carryover from the worktime. Worktime no longer includes the previous months carryover.