### PR TITLE
Fix Deprovision

### DIFF
--- a/api/idm/deprovisioning.py
+++ b/api/idm/deprovisioning.py
@@ -44,7 +44,9 @@ class Deprovisioner:
         self.SECRET_KEY = bytes.fromhex(env.str("IDM_SECRET_KEY"))
         self.queryset = user_queryset if user_queryset else self.get_queryset()
         self.request_bodies = []
-        self.last_deprovision_time = (datetime.datetime.now()-relativedelta(months=1)).timestamp()*1000
+        self.last_deprovision_time = (
+            datetime.datetime.now() - relativedelta(months=1)
+        ).timestamp() * 1000
         self.update_cnt = 0
 
     @property
@@ -58,7 +60,9 @@ class Deprovisioner:
         return self.model.objects.all().exclude(username="")
 
     def create_hmac(self, request_body):
-        encoded_data = self.idm_api_url + request_body + self.API_KEY + str(self.current_time)
+        encoded_data = (
+            self.idm_api_url + request_body + self.API_KEY + str(self.current_time)
+        )
 
         b64mac = base64.b64encode(
             hmac.new(
@@ -109,8 +113,12 @@ class Deprovisioner:
                 "filter": [
                     f"db.hrzlogin={getattr(obj, self.identifier_field)} && db.accountstatus=L"
                 ],
-                #the "timestamp" is a pseudo filter used by the json-rpc endpoint to filter by "last_changed">"timestamp"
-                "datain": {"timestamp": self.last_deprovision_time, "returns": None, "debug": False},
+                # the "timestamp" is a pseudo filter used by the json-rpc endpoint to filter by "last_changed">"timestamp"
+                "datain": {
+                    "timestamp": self.last_deprovision_time,
+                    "returns": None,
+                    "debug": False,
+                },
             },
         }
         return body_obj

--- a/api/tests/test_deprovisioning.py
+++ b/api/tests/test_deprovisioning.py
@@ -57,8 +57,8 @@ class TestClassAttributes:
     def test_has_request_bodies(self):
         assert hasattr(self.instance, "request_bodies")
 
-    def test_has_time(self):
-        assert hasattr(self.instance, "time")
+    def test_has_current_time(self):
+        assert hasattr(self.instance, "current_time")
 
     # Test for existing methods
     def test_has_get_model(self):
@@ -148,7 +148,9 @@ class TestDeprovisionSteps:
         body = test_deprovisioner_instance.prepare_obj_json_rpc(
             first_deprovision_test_user
         )
-        frozen_unix_epoch = int(time.time() * 1000)
+        frozen_unix_epoch = (
+            datetime.datetime.now() - relativedelta(months=1)
+        ).timestamp() * 1000
         correct_body = {
             "jsonrpc": "2.0",
             "method": "idm.read",

--- a/api/tests/test_deprovisioning.py
+++ b/api/tests/test_deprovisioning.py
@@ -18,6 +18,7 @@ import json
 import time
 
 import pytest
+from dateutil.relativedelta import relativedelta
 
 from api.idm.deprovisioning import Deprovisioner
 from api.models import User
@@ -59,6 +60,9 @@ class TestClassAttributes:
 
     def test_has_current_time(self):
         assert hasattr(self.instance, "current_time")
+
+    def test_has_last_deprovision_time(self):
+        assert hasattr(self.instance, "last_deprovision_time")
 
     # Test for existing methods
     def test_has_get_model(self):


### PR DESCRIPTION
The Deprovisioner Class made incorrect use of the "timestamp" field.
This is fixed and was manually executed and verified.